### PR TITLE
MeanAveragePrecision: Skip box conversion if no boxes are present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed mAP calculation for areas with 0 predictions ([#1080](https://github.com/PyTorchLightning/metrics/pull/1080))
 
+
 - Fixed bug where avg precision state and auroc state was not merge when using MetricCollections ([#1086](https://github.com/PyTorchLightning/metrics/pull/1086))
+
+
+- Skip box conversion if no boxes are present in `MeanAveragePrecision` ([#1097](https://github.com/PyTorchLightning/metrics/pull/1097))
 
 
 ## [0.9.1] - 2022-06-08

--- a/src/torchmetrics/detection/mean_ap.py
+++ b/src/torchmetrics/detection/mean_ap.py
@@ -416,7 +416,8 @@ class MeanAveragePrecision(Metric):
 
         if self.iou_type == "bbox":
             boxes = _fix_empty_tensors(item["boxes"])
-            boxes = box_convert(boxes, in_fmt=self.box_format, out_fmt="xyxy")
+            if boxes.numel() > 0:
+                boxes = box_convert(boxes, in_fmt=self.box_format, out_fmt="xyxy")
             return boxes
         elif self.iou_type == "segm":
             masks = []

--- a/tests/unittests/detection/test_map.py
+++ b/tests/unittests/detection/test_map.py
@@ -342,12 +342,8 @@ def test_empty_preds():
     metric = MeanAveragePrecision()
 
     metric.update(
-        [
-            dict(boxes=Tensor([]), scores=Tensor([]), labels=IntTensor([])),
-        ],
-        [
-            dict(boxes=Tensor([[214.1500, 41.2900, 562.4100, 285.0700]]), labels=IntTensor([4])),
-        ],
+        [dict(boxes=Tensor([]), scores=Tensor([]), labels=IntTensor([]))],
+        [dict(boxes=Tensor([[214.1500, 41.2900, 562.4100, 285.0700]]), labels=IntTensor([4]))],
     )
     metric.compute()
 
@@ -358,16 +354,8 @@ def test_empty_ground_truths():
     metric = MeanAveragePrecision()
 
     metric.update(
-        [
-            dict(
-                boxes=Tensor([[214.1500, 41.2900, 562.4100, 285.0700]]),
-                scores=Tensor([0.5]),
-                labels=IntTensor([4]),
-            ),
-        ],
-        [
-            dict(boxes=Tensor([]), labels=IntTensor([])),
-        ],
+        [dict(boxes=Tensor([[214.1500, 41.2900, 562.4100, 285.0700]]), scores=Tensor([0.5]), labels=IntTensor([4]))],
+        [dict(boxes=Tensor([]), labels=IntTensor([]))],
     )
     metric.compute()
 
@@ -378,16 +366,8 @@ def test_empty_ground_truths_xywh():
     metric = MeanAveragePrecision(box_format="xywh")
 
     metric.update(
-        [
-            dict(
-                boxes=Tensor([[214.1500, 41.2900, 348.2600, 243.7800]]),
-                scores=Tensor([0.5]),
-                labels=IntTensor([4]),
-            ),
-        ],
-        [
-            dict(boxes=Tensor([]), labels=IntTensor([])),
-        ],
+        [dict(boxes=Tensor([[214.1500, 41.2900, 348.2600, 243.7800]]), scores=Tensor([0.5]), labels=IntTensor([4]))],
+        [dict(boxes=Tensor([]), labels=IntTensor([]))],
     )
     metric.compute()
 
@@ -398,12 +378,8 @@ def test_empty_preds_xywh():
     metric = MeanAveragePrecision(box_format="xywh")
 
     metric.update(
-        [
-            dict(boxes=Tensor([]), scores=Tensor([]), labels=IntTensor([])),
-        ],
-        [
-            dict(boxes=Tensor([[214.1500, 41.2900, 348.2600, 243.7800]]), labels=IntTensor([4])),
-        ],
+        [dict(boxes=Tensor([]), scores=Tensor([]), labels=IntTensor([]))],
+        [dict(boxes=Tensor([[214.1500, 41.2900, 348.2600, 243.7800]]), labels=IntTensor([4]))],
     )
     metric.compute()
 
@@ -414,16 +390,8 @@ def test_empty_ground_truths_cxcywh():
     metric = MeanAveragePrecision(box_format="cxcywh")
 
     metric.update(
-        [
-            dict(
-                boxes=Tensor([[388.2800, 163.1800, 348.2600, 243.7800]]),
-                scores=Tensor([0.5]),
-                labels=IntTensor([4]),
-            ),
-        ],
-        [
-            dict(boxes=Tensor([]), labels=IntTensor([])),
-        ],
+        [dict(boxes=Tensor([[388.2800, 163.1800, 348.2600, 243.7800]]), scores=Tensor([0.5]), labels=IntTensor([4]))],
+        [dict(boxes=Tensor([]), labels=IntTensor([]))],
     )
     metric.compute()
 
@@ -434,12 +402,8 @@ def test_empty_preds_cxcywh():
     metric = MeanAveragePrecision(box_format="cxcywh")
 
     metric.update(
-        [
-            dict(boxes=Tensor([]), scores=Tensor([]), labels=IntTensor([])),
-        ],
-        [
-            dict(boxes=Tensor([[388.2800, 163.1800, 348.2600, 243.7800]]), labels=IntTensor([4])),
-        ],
+        [dict(boxes=Tensor([]), scores=Tensor([]), labels=IntTensor([]))],
+        [dict(boxes=Tensor([[388.2800, 163.1800, 348.2600, 243.7800]]), labels=IntTensor([4]))],
     )
     metric.compute()
 

--- a/tests/unittests/detection/test_map.py
+++ b/tests/unittests/detection/test_map.py
@@ -56,7 +56,6 @@ _inputs_masks = Input(
     ],
 )
 
-
 _inputs = Input(
     preds=[
         [
@@ -299,7 +298,6 @@ class TestMAP(MetricTester):
 
     @pytest.mark.parametrize("ddp", [False, True])
     def test_map_bbox(self, compute_on_cpu, ddp):
-
         """Test modular implementation for correctness."""
         self.run_class_metric_test(
             ddp=ddp,
@@ -369,6 +367,78 @@ def test_empty_ground_truths():
         ],
         [
             dict(boxes=Tensor([]), labels=IntTensor([])),
+        ],
+    )
+    metric.compute()
+
+
+@pytest.mark.skipif(_pytest_condition, reason="test requires that torchvision=>0.8.0 is installed")
+def test_empty_ground_truths_xywh():
+    """Test empty ground truths in xywh format."""
+    metric = MeanAveragePrecision(box_format="xywh")
+
+    metric.update(
+        [
+            dict(
+                boxes=Tensor([[214.1500, 41.2900, 348.2600, 243.7800]]),
+                scores=Tensor([0.5]),
+                labels=IntTensor([4]),
+            ),
+        ],
+        [
+            dict(boxes=Tensor([]), labels=IntTensor([])),
+        ],
+    )
+    metric.compute()
+
+
+@pytest.mark.skipif(_pytest_condition, reason="test requires that torchvision=>0.8.0 is installed")
+def test_empty_preds_xywh():
+    """Test empty predictions in xywh format."""
+    metric = MeanAveragePrecision(box_format="xywh")
+
+    metric.update(
+        [
+            dict(boxes=Tensor([]), scores=Tensor([]), labels=IntTensor([])),
+        ],
+        [
+            dict(boxes=Tensor([[214.1500, 41.2900, 348.2600, 243.7800]]), labels=IntTensor([4])),
+        ],
+    )
+    metric.compute()
+
+
+@pytest.mark.skipif(_pytest_condition, reason="test requires that torchvision=>0.8.0 is installed")
+def test_empty_ground_truths_cxcywh():
+    """Test empty ground truths in cxcywh format."""
+    metric = MeanAveragePrecision(box_format="cxcywh")
+
+    metric.update(
+        [
+            dict(
+                boxes=Tensor([[388.2800, 163.1800, 348.2600, 243.7800]]),
+                scores=Tensor([0.5]),
+                labels=IntTensor([4]),
+            ),
+        ],
+        [
+            dict(boxes=Tensor([]), labels=IntTensor([])),
+        ],
+    )
+    metric.compute()
+
+
+@pytest.mark.skipif(_pytest_condition, reason="test requires that torchvision=>0.8.0 is installed")
+def test_empty_preds_cxcywh():
+    """Test empty predictions in cxcywh format."""
+    metric = MeanAveragePrecision(box_format="cxcywh")
+
+    metric.update(
+        [
+            dict(boxes=Tensor([]), scores=Tensor([]), labels=IntTensor([])),
+        ],
+        [
+            dict(boxes=Tensor([[388.2800, 163.1800, 348.2600, 243.7800]]), labels=IntTensor([4])),
         ],
     )
     metric.compute()

--- a/tests/unittests/detection/test_map.py
+++ b/tests/unittests/detection/test_map.py
@@ -541,12 +541,12 @@ def test_segm_iou_empty_gt_mask():
             dict(
                 masks=torch.randint(0, 1, (1, 10, 10)).bool(),
                 scores=Tensor([0.5]),
-                labels=IntTensor([4]),
-            ),
+                labels=IntTensor([4])
+            )
         ],
         [
-            dict(masks=Tensor([]), labels=IntTensor([])),
-        ],
+            dict(masks=Tensor([]), labels=IntTensor([]))
+        ]
     )
 
     metric.compute()
@@ -562,12 +562,12 @@ def test_segm_iou_empty_pred_mask():
             dict(
                 masks=torch.BoolTensor([]),
                 scores=Tensor([]),
-                labels=IntTensor([]),
-            ),
+                labels=IntTensor([])
+            )
         ],
         [
-            dict(masks=torch.randint(0, 1, (1, 10, 10)).bool(), labels=IntTensor([4])),
-        ],
+            dict(masks=torch.randint(0, 1, (1, 10, 10)).bool(), labels=IntTensor([4]))
+        ]
     )
 
     metric.compute()

--- a/tests/unittests/detection/test_map.py
+++ b/tests/unittests/detection/test_map.py
@@ -537,16 +537,8 @@ def test_segm_iou_empty_gt_mask():
     metric = MeanAveragePrecision(iou_type="segm")
 
     metric.update(
-        [
-            dict(
-                masks=torch.randint(0, 1, (1, 10, 10)).bool(),
-                scores=Tensor([0.5]),
-                labels=IntTensor([4])
-            )
-        ],
-        [
-            dict(masks=Tensor([]), labels=IntTensor([]))
-        ]
+        [dict(masks=torch.randint(0, 1, (1, 10, 10)).bool(), scores=Tensor([0.5]), labels=IntTensor([4]))],
+        [dict(masks=Tensor([]), labels=IntTensor([]))],
     )
 
     metric.compute()
@@ -558,16 +550,8 @@ def test_segm_iou_empty_pred_mask():
     metric = MeanAveragePrecision(iou_type="segm")
 
     metric.update(
-        [
-            dict(
-                masks=torch.BoolTensor([]),
-                scores=Tensor([]),
-                labels=IntTensor([])
-            )
-        ],
-        [
-            dict(masks=torch.randint(0, 1, (1, 10, 10)).bool(), labels=IntTensor([4]))
-        ]
+        [dict(masks=torch.BoolTensor([]), scores=Tensor([]), labels=IntTensor([]))],
+        [dict(masks=torch.randint(0, 1, (1, 10, 10)).bool(), labels=IntTensor([4]))],
     )
 
     metric.compute()


### PR DESCRIPTION
The `box_convert` function from torchvision expects the input to be a
Tensor[N, 4], where N > 0. Should N == 0 and in_fmt != out_fmt, `unbind`
will error out on the boxes tensor during the conversion process.

The workaround is therefore to skip the box conversion if boxes is an
empty tensor.

## What does this PR do?

Fixes #1096 

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/PyTorchLightning/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
