### PR TITLE
Add "none" option to AveragePrecision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Skip box conversion if no boxes are present in `MeanAveragePrecision` ([#1097](https://github.com/Lightning-AI/metrics/pull/1097))
 
 
+- Fixed inconsistency in docs and code when setting `average="none"` in `AvaragePrecision` metric ([#1116](https://github.com/Lightning-AI/metrics/pull/1116))
+
+
 ## [0.9.1] - 2022-06-08
 
 ### Added

--- a/src/torchmetrics/functional/classification/average_precision.py
+++ b/src/torchmetrics/functional/classification/average_precision.py
@@ -167,9 +167,9 @@ def _average_precision_compute_with_precision_recall(
             return res[~torch.isnan(res)].mean()
         weights = torch.ones_like(res) if weights is None else weights
         return (res * weights)[~torch.isnan(res)].sum()
-    if average is None:
+    if average is None or average == "none":
         return res
-    allowed_average = ("micro", "macro", "weighted", None)
+    allowed_average = ("micro", "macro", "weighted", "none", None)
     raise ValueError(f"Expected argument `average` to be one of {allowed_average}" f" but got {average}")
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes #1106
Docs state that `average="none"` is also an option for average precision metric, but currently it is not

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
