### PR TITLE
Fix: JaccardIndex multi-label compute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 
--
+- Fixed JaccardIndex multi-label compute ([#1125](https://github.com/Lightning-AI/metrics/pull/1125))
 
 
 

--- a/src/torchmetrics/classification/jaccard.py
+++ b/src/torchmetrics/classification/jaccard.py
@@ -126,4 +126,3 @@ class JaccardIndex(ConfusionMatrix):
                 self.ignore_index,
                 self.absent_score,
             )
-

--- a/src/torchmetrics/classification/jaccard.py
+++ b/src/torchmetrics/classification/jaccard.py
@@ -104,10 +104,26 @@ class JaccardIndex(ConfusionMatrix):
 
     def compute(self) -> Tensor:
         """Computes intersection over union (IoU)"""
-        return _jaccard_from_confmat(
-            self.confmat,
-            self.num_classes,
-            self.average,
-            self.ignore_index,
-            self.absent_score,
-        )
+
+        if self.multilabel:
+            return torch.stack(
+                [
+                    _jaccard_from_confmat(
+                        confmat,
+                        2,
+                        self.average,
+                        self.ignore_index,
+                        self.absent_score,
+                    )[1]
+                    for confmat in self.confmat
+                ]
+            )
+        else:
+            return _jaccard_from_confmat(
+                self.confmat,
+                self.num_classes,
+                self.average,
+                self.ignore_index,
+                self.absent_score,
+            )
+


### PR DESCRIPTION


## What does this PR do?

The shape of the matrix in multi-label mode is (nb_classes, 2, 2) and currently the compute function needs a shape of (nb_classes, nb_classes). Easy fix by a for loop in the jaccardindex compute 

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?
