### PR TITLE
Bugfix: Update message regarding connection issues to the HF hub

### DIFF
--- a/tests/unittests/text/helpers.py
+++ b/tests/unittests/text/helpers.py
@@ -440,7 +440,7 @@ def skip_on_connection_issues(reason: str = "Unable to load checkpoints from Hug
 
     The tests run normally if no connection issue arises, and they're marked as skipped otherwise.
     """
-    _error_msg_starts = ["We couldn't connect to", "Connection error"]
+    _error_msg_starts = ["We couldn't connect to", "Connection error", "Can't load"]
 
     def test_decorator(function: Callable, *args: Any, **kwargs: Any) -> Optional[Callable]:
         @wraps(function)

--- a/tests/unittests/text/helpers.py
+++ b/tests/unittests/text/helpers.py
@@ -440,7 +440,7 @@ def skip_on_connection_issues(reason: str = "Unable to load checkpoints from Hug
 
     The tests run normally if no connection issue arises, and they're marked as skipped otherwise.
     """
-    _error_msg_start = "We couldn't connect to"
+    _error_msg_starts = ["We couldn't connect to", "Connection error"]
 
     def test_decorator(function: Callable, *args: Any, **kwargs: Any) -> Optional[Callable]:
         @wraps(function)
@@ -448,7 +448,7 @@ def skip_on_connection_issues(reason: str = "Unable to load checkpoints from Hug
             try:
                 return function(*args, **kwargs)
             except OSError as ex:
-                if _error_msg_start not in str(ex):
+                if all(msg_start not in str(ex) for msg_start in _error_msg_starts):
                     raise ex
                 pytest.skip(reason)
 

--- a/tests/unittests/text/helpers.py
+++ b/tests/unittests/text/helpers.py
@@ -447,7 +447,7 @@ def skip_on_connection_issues(reason: str = "Unable to load checkpoints from Hug
         def run_test(*args: Any, **kwargs: Any) -> Optional[Any]:
             try:
                 return function(*args, **kwargs)
-            except OSError as ex:
+            except (OSError, ValueError) as ex:
                 if all(msg_start not in str(ex) for msg_start in _error_msg_starts):
                     raise ex
                 pytest.skip(reason)


### PR DESCRIPTION
## What does this PR do?

When there's a connection issue to the HF hub, we try to catch this exception using `skip_on_connection_issues` decorator. However, it seems the error message has changed or there might be multiple ones. We thus catch more variants of potential raises.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
