### PR TITLE
Fix: (SSIM) propagate device if `gaussian_kernel` is False, add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed JaccardIndex multi-label compute ([#1125](https://github.com/Lightning-AI/metrics/pull/1125))
 
 
+- Fix SSIM propagate device if `gaussian_kernel` is False, add test ([#1149](https://github.com/Lightning-AI/metrics/pull/1149))
+
+
 
 ## [0.9.2] - 2022-06-29
 

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from typing import List, Optional, Sequence, Tuple, Union
 
+import math
 import torch
 from torch import Tensor
 from torch.nn import functional as F

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -150,9 +150,7 @@ def _ssim_compute(
             kernel = _gaussian_kernel_2d(channel, gauss_kernel_size, sigma, dtype, device)
 
     if not gaussian_kernel:
-        kernel = torch.ones((channel, 1, *kernel_size), dtype=dtype, device=device) / torch.prod(
-            torch.tensor(kernel_size, dtype=dtype, device=device)
-        )
+        kernel = torch.ones((channel, 1, *kernel_size), dtype=dtype, device=device) / math.prod(kernel_size)
 
     input_list = torch.cat((preds, target, preds * preds, target * target, preds * target))  # (5 * B, C, H, W)
 

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -150,7 +150,7 @@ def _ssim_compute(
             kernel = _gaussian_kernel_2d(channel, gauss_kernel_size, sigma, dtype, device)
 
     if not gaussian_kernel:
-        kernel = torch.ones((1, 1, *kernel_size), device=device) / torch.prod(Tensor(kernel_size, device=device))
+        kernel = torch.ones((channel, 1, *kernel_size), dtype=dtype, device=device) / torch.prod(torch.tensor(kernel_size, dtype=dtype, device=device))
 
     input_list = torch.cat((preds, target, preds * preds, target * target, preds * target))  # (5 * B, C, H, W)
 

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -150,7 +150,9 @@ def _ssim_compute(
             kernel = _gaussian_kernel_2d(channel, gauss_kernel_size, sigma, dtype, device)
 
     if not gaussian_kernel:
-        kernel = torch.ones((channel, 1, *kernel_size), dtype=dtype, device=device) / torch.prod(torch.tensor(kernel_size, dtype=dtype, device=device))
+        kernel = torch.ones((channel, 1, *kernel_size), dtype=dtype, device=device) / torch.prod(
+            torch.tensor(kernel_size, dtype=dtype, device=device)
+        )
 
     input_list = torch.cat((preds, target, preds * preds, target * target, preds * target))  # (5 * B, C, H, W)
 

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -11,9 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import math
 from typing import List, Optional, Sequence, Tuple, Union
 
-import math
 import torch
 from torch import Tensor
 from torch.nn import functional as F

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -150,7 +150,7 @@ def _ssim_compute(
             kernel = _gaussian_kernel_2d(channel, gauss_kernel_size, sigma, dtype, device)
 
     if not gaussian_kernel:
-        kernel = torch.ones((1, 1, *kernel_size)) / torch.prod(Tensor(kernel_size))
+        kernel = torch.ones((1, 1, *kernel_size), device=device) / torch.prod(Tensor(kernel_size, device=device))
 
     input_list = torch.cat((preds, target, preds * preds, target * target, preds * target))  # (5 * B, C, H, W)
 

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import math
 from typing import List, Optional, Sequence, Tuple, Union
 
 import torch
@@ -151,7 +150,7 @@ def _ssim_compute(
             kernel = _gaussian_kernel_2d(channel, gauss_kernel_size, sigma, dtype, device)
 
     if not gaussian_kernel:
-        kernel = torch.ones((channel, 1, *kernel_size), dtype=dtype, device=device) / math.prod(kernel_size)
+        kernel = torch.ones((channel, 1, *kernel_size), dtype=dtype, device=device) / torch.prod(torch.tensor(kernel_size, dtype=dtype, device=device))
 
     input_list = torch.cat((preds, target, preds * preds, target * target, preds * target))  # (5 * B, C, H, W)
 

--- a/tests/unittests/image/test_ssim.py
+++ b/tests/unittests/image/test_ssim.py
@@ -142,7 +142,6 @@ class TestSSIM(MetricTester):
             dist_sync_on_step=dist_sync_on_step,
         )
 
-
     def test_ssim_functional(self, preds, target, sigma):
         self.run_functional_metric_test(
             preds,

--- a/tests/unittests/image/test_ssim.py
+++ b/tests/unittests/image/test_ssim.py
@@ -125,6 +125,24 @@ class TestSSIM(MetricTester):
             dist_sync_on_step=dist_sync_on_step,
         )
 
+    @pytest.mark.parametrize("ddp", [True, False])
+    @pytest.mark.parametrize("dist_sync_on_step", [True, False])
+    def test_ssim_without_gaussian_kernel(self, preds, target, sigma, ddp, dist_sync_on_step):
+        self.run_class_metric_test(
+            ddp,
+            preds,
+            target,
+            StructuralSimilarityIndexMeasure,
+            partial(_sk_ssim, data_range=1.0, sigma=sigma, kernel_size=None),
+            metric_args={
+                "gaussian_kernel": False,
+                "data_range": 1.0,
+                "sigma": sigma,
+            },
+            dist_sync_on_step=dist_sync_on_step,
+        )
+
+
     def test_ssim_functional(self, preds, target, sigma):
         self.run_functional_metric_test(
             preds,


### PR DESCRIPTION
## What does this PR do?

Attempts to fix #1148 - summary of the changes:

1. The `device`, `dtype` and `channel` are now propagated if `gaussian_kernel` is `False`.
2. A test has been added as well.

~_Note to reviewers: I'm away from my GPU machine, so couldn't test this yet, I'll keep an eye on the CI, else I'll test it on my machine by tomorrow._~ (Tested on a GPU machine, all tests pass locally)

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
