### PR TITLE
Fix integration tests for lightning 1.7

### DIFF
--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -57,7 +57,6 @@ def test_metric_lightning(tmpdir):
         limit_val_batches=2,
         max_epochs=2,
         log_every_n_steps=1,
-        weights_summary=None,
     )
     trainer.fit(model)
 
@@ -252,7 +251,6 @@ def test_metric_collection_lightning_log(tmpdir):
         limit_val_batches=0,
         max_epochs=1,
         log_every_n_steps=1,
-        weights_summary=None,
     )
     with no_warning_call(
         UserWarning,
@@ -290,7 +288,6 @@ def test_scriptable(tmpdir):
         limit_val_batches=2,
         max_epochs=1,
         log_every_n_steps=1,
-        weights_summary=None,
         logger=False,
         checkpoint_callback=False,
     )

--- a/tests/integrations/test_lightning.py
+++ b/tests/integrations/test_lightning.py
@@ -289,7 +289,6 @@ def test_scriptable(tmpdir):
         max_epochs=1,
         log_every_n_steps=1,
         logger=False,
-        checkpoint_callback=False,
     )
     trainer.fit(model)
     rand_input = torch.randn(10, 32)


### PR DESCRIPTION
## What does this PR do?

`weights_summary` and `checkpoint_callback` is gone in 1.7 of lightning. Removes arg from integration tests.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
