### PR TITLE
Removed micro average doc string from auroc

### DIFF
--- a/src/torchmetrics/classification/auroc.py
+++ b/src/torchmetrics/classification/auroc.py
@@ -55,7 +55,6 @@ class AUROC(Metric):
             this argument should not be set as we iteratively change it in the
             range ``[0, num_classes-1]``
         average:
-            - ``'micro'`` computes metric globally. Only works for multilabel problems
             - ``'macro'`` computes metric for each class and uniformly averages them
             - ``'weighted'`` computes metric for each class and does a weighted-average,
               where each class is weighted by their support (accounts for class imbalance)


### PR DESCRIPTION
## What does this PR do?

Removes docstring mistake. Average `micro` is not available for auroc.

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Sure!
