### PR TITLE
Fix reduction for full image in SSIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
--
+- Fixed a bug in `ssim` when `return_full_image=True` where the score was still reduced ([#1204](https://github.com/Lightning-AI/metrics/pull/1204))
 
 
 -

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -69,7 +69,7 @@ def _ssim_compute(
             Ignored if a uniform kernel is used
         kernel_size: the size of the uniform kernel, anisotropic kernels are possible.
             Ignored if a Gaussian kernel is used
-        reduction: a method to reduce metric score over labels.
+        reduction: a method to reduce metric score over individual batch scores
 
             - ``'elementwise_mean'``: takes the mean
             - ``'sum'``: takes the sum
@@ -116,6 +116,9 @@ def _ssim_compute(
         raise ValueError(
             f"Expected `kernel_size` dimension to be 2 or 3. `kernel_size` dimensionality: {len(kernel_size)}"
         )
+
+    if return_full_image and return_contrast_sensitivity:
+        raise ValueError("Arguments `return_full_image` and `return_contrast_sensitivity` are mutually exclusive.")
 
     if any(x % 2 == 0 or x <= 0 for x in kernel_size):
         raise ValueError(f"Expected `kernel_size` to have odd positive number. Got {kernel_size}.")
@@ -189,9 +192,7 @@ def _ssim_compute(
         )
 
     elif return_full_image:
-        return reduce(ssim_idx.reshape(ssim_idx.shape[0], -1).mean(-1), reduction), reduce(
-            ssim_idx_full_image, reduction
-        )
+        return reduce(ssim_idx.reshape(ssim_idx.shape[0], -1).mean(-1), reduction), ssim_idx_full_image
 
     return reduce(ssim_idx.reshape(ssim_idx.shape[0], -1).mean(-1), reduction)
 

--- a/src/torchmetrics/image/ssim.py
+++ b/src/torchmetrics/image/ssim.py
@@ -33,7 +33,7 @@ class StructuralSimilarityIndexMeasure(Metric):
             Ignored if a uniform kernel is used
         kernel_size: the size of the uniform kernel, anisotropic kernels are possible.
             Ignored if a Gaussian kernel is used
-        reduction: a method to reduce metric score over labels.
+        reduction: a method to reduce metric score over individual batch scores
 
             - ``'elementwise_mean'``: takes the mean
             - ``'sum'``: takes the sum


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/metrics/issues/1186
Removes the reduction that is done in `ssim` when `return_full_image=True`, as the argument name indicates in this case no reduction should be applied.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
