### PR TITLE
[MPS support] Make Jaccard Index working on MPS

### DIFF
--- a/src/torchmetrics/functional/classification/jaccard.py
+++ b/src/torchmetrics/functional/classification/jaccard.py
@@ -62,7 +62,7 @@ def _jaccard_from_confmat(
 
         # If this class is absent in both target AND pred (union == 0), then use the absent_score for this class.
         scores = intersection.float() / union.float()
-        scores[union == 0] = absent_score
+        scores.where(union == 0, torch.tensor(absent_score, dtype=scores.dtype, device=scores.device))
 
         if ignore_index is not None and 0 <= ignore_index < num_classes:
             scores = torch.cat(

--- a/src/torchmetrics/utilities/data.py
+++ b/src/torchmetrics/utilities/data.py
@@ -242,7 +242,10 @@ def _squeeze_if_scalar(data: Any) -> Any:
 
 
 def _bincount(x: Tensor, minlength: Optional[int] = None) -> Tensor:
-    """``torch.bincount`` currently does not support deterministic mode on GPU.
+    """PyTorch currently does not support``torch.bincount`` for:
+
+        - deterministic mode on GPU.
+        - MPS devices
 
     This implementation fallback to a for-loop counting occurrences in that case.
 
@@ -253,7 +256,7 @@ def _bincount(x: Tensor, minlength: Optional[int] = None) -> Tensor:
     Returns:
         Number of occurrences for each unique element in x
     """
-    if x.is_cuda and deterministic():
+    if (x.is_cuda and deterministic()) or x.is_mps:
         if minlength is None:
             minlength = len(torch.unique(x))
         output = torch.zeros(minlength, device=x.device, dtype=torch.long)


### PR DESCRIPTION
Fixes #1196

* Change `_bincount` calculation for `MPS` to run for loop fallback
* Use `torch.where` implementation to apply `absent_score` instead of relying on item assignment

There's still a warning on PyTorch side (using CPU fallback for some operations), however,
no actions on our users' side are now required and the results are obtained smoothly.

## What does this PR do?

Fixes #\<issue_number>

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
