### PR TITLE
Fix bug for initialization of state in approximative methods

### DIFF
--- a/src/torchmetrics/classification/precision_recall_curve.py
+++ b/src/torchmetrics/classification/precision_recall_curve.py
@@ -125,7 +125,9 @@ class BinaryPrecisionRecallCurve(Metric):
             self.add_state("target", default=[], dist_reduce_fx="cat")
         else:
             self.register_buffer("thresholds", _adjust_threshold_arg(thresholds))
-            self.add_state("confmat", default=torch.zeros(thresholds, 2, 2, dtype=torch.long), dist_reduce_fx="sum")
+            self.add_state(
+                "confmat", default=torch.zeros(len(self.thresholds), 2, 2, dtype=torch.long), dist_reduce_fx="sum"
+            )
 
     def update(self, preds: Tensor, target: Tensor) -> None:  # type: ignore
         if self.validate_args:
@@ -254,7 +256,9 @@ class MulticlassPrecisionRecallCurve(Metric):
         else:
             self.register_buffer("thresholds", _adjust_threshold_arg(thresholds))
             self.add_state(
-                "confmat", default=torch.zeros(thresholds, num_classes, 2, 2, dtype=torch.long), dist_reduce_fx="sum"
+                "confmat",
+                default=torch.zeros(len(self.thresholds), num_classes, 2, 2, dtype=torch.long),
+                dist_reduce_fx="sum",
             )
 
     def update(self, preds: Tensor, target: Tensor) -> None:  # type: ignore
@@ -388,7 +392,9 @@ class MultilabelPrecisionRecallCurve(Metric):
         else:
             self.register_buffer("thresholds", _adjust_threshold_arg(thresholds))
             self.add_state(
-                "confmat", default=torch.zeros(thresholds, num_labels, 2, 2, dtype=torch.long), dist_reduce_fx="sum"
+                "confmat",
+                default=torch.zeros(len(self.thresholds), num_labels, 2, 2, dtype=torch.long),
+                dist_reduce_fx="sum",
             )
 
     def update(self, preds: Tensor, target: Tensor) -> None:  # type: ignore

--- a/tests/unittests/classification/test_auroc.py
+++ b/tests/unittests/classification/test_auroc.py
@@ -359,3 +359,19 @@ class TestMultilabelAUROC(MetricTester):
                 pred, true, num_labels=NUM_CLASSES, average=average, thresholds=torch.linspace(0, 1, 100)
             )
             assert torch.allclose(ap1, ap2)
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        BinaryAUROC,
+        partial(MulticlassAUROC, num_classes=NUM_CLASSES),
+        partial(MultilabelAUROC, num_labels=NUM_CLASSES),
+    ],
+)
+@pytest.mark.parametrize("thresholds", [None, 100, [0.3, 0.5, 0.7, 0.9], torch.linspace(0, 1, 10)])
+def test_valid_input_thresholds(metric, thresholds):
+    """test valid formats of the threshold argument."""
+    with pytest.warns(None) as record:
+        metric(thresholds=thresholds)
+    assert len(record) == 0

--- a/tests/unittests/classification/test_average_precision.py
+++ b/tests/unittests/classification/test_average_precision.py
@@ -363,3 +363,19 @@ class TestMultilabelAveragePrecision(MetricTester):
                 pred, true, num_labels=NUM_CLASSES, average=average, thresholds=torch.linspace(0, 1, 100)
             )
             assert torch.allclose(ap1, ap2)
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        BinaryAveragePrecision,
+        partial(MulticlassAveragePrecision, num_classes=NUM_CLASSES),
+        partial(MultilabelAveragePrecision, num_labels=NUM_CLASSES),
+    ],
+)
+@pytest.mark.parametrize("thresholds", [None, 100, [0.3, 0.5, 0.7, 0.9], torch.linspace(0, 1, 10)])
+def test_valid_input_thresholds(metric, thresholds):
+    """test valid formats of the threshold argument."""
+    with pytest.warns(None) as record:
+        metric(thresholds=thresholds)
+    assert len(record) == 0

--- a/tests/unittests/classification/test_precision_recall_curve.py
+++ b/tests/unittests/classification/test_precision_recall_curve.py
@@ -351,3 +351,19 @@ class TestMultilabelPrecisionRecallCurve(MetricTester):
                 assert torch.allclose(p1[i], p2[i])
                 assert torch.allclose(r1[i], r2[i])
                 assert torch.allclose(t1[i], t2)
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        BinaryPrecisionRecallCurve,
+        partial(MulticlassPrecisionRecallCurve, num_classes=NUM_CLASSES),
+        partial(MultilabelPrecisionRecallCurve, num_labels=NUM_CLASSES),
+    ],
+)
+@pytest.mark.parametrize("thresholds", [None, 100, [0.3, 0.5, 0.7, 0.9], torch.linspace(0, 1, 10)])
+def test_valid_input_thresholds(metric, thresholds):
+    """test valid formats of the threshold argument."""
+    with pytest.warns(None) as record:
+        metric(thresholds=thresholds)
+    assert len(record) == 0

--- a/tests/unittests/classification/test_recall_at_fixed_precision.py
+++ b/tests/unittests/classification/test_recall_at_fixed_precision.py
@@ -387,3 +387,19 @@ class TestMultilabelRecallAtFixedPrecision(MetricTester):
                 pred, true, num_labels=NUM_CLASSES, min_precision=min_precision, thresholds=torch.linspace(0, 1, 100)
             )
             assert all(torch.allclose(r1[i], r2[i]) for i in range(len(r1)))
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        BinaryRecallAtFixedPrecision,
+        partial(MulticlassRecallAtFixedPrecision, num_classes=NUM_CLASSES),
+        partial(MultilabelRecallAtFixedPrecision, num_labels=NUM_CLASSES),
+    ],
+)
+@pytest.mark.parametrize("thresholds", [None, 100, [0.3, 0.5, 0.7, 0.9], torch.linspace(0, 1, 10)])
+def test_valid_input_thresholds(metric, thresholds):
+    """test valid formats of the threshold argument."""
+    with pytest.warns(None) as record:
+        metric(min_precision=0.5, thresholds=thresholds)
+    assert len(record) == 0

--- a/tests/unittests/classification/test_roc.py
+++ b/tests/unittests/classification/test_roc.py
@@ -340,3 +340,19 @@ class TestMultilabelROC(MetricTester):
                 assert torch.allclose(p1[i], p2[i])
                 assert torch.allclose(r1[i], r2[i])
                 assert torch.allclose(t1[i], t2)
+
+
+@pytest.mark.parametrize(
+    "metric",
+    [
+        BinaryROC,
+        partial(MulticlassROC, num_classes=NUM_CLASSES),
+        partial(MultilabelROC, num_labels=NUM_CLASSES),
+    ],
+)
+@pytest.mark.parametrize("thresholds", [None, 100, [0.3, 0.5, 0.7, 0.9], torch.linspace(0, 1, 10)])
+def test_valid_input_thresholds(metric, thresholds):
+    """test valid formats of the threshold argument."""
+    with pytest.warns(None) as record:
+        metric(thresholds=thresholds)
+    assert len(record) == 0


### PR DESCRIPTION
## What does this PR do?

Fixes bug I found while writing blogpost about release.
For `auroc`, `precision_recall_curve` etc. the new `thresholds` argument was not correctly used when initializing states. This PR fixes it and adds test for all the affected metrics.

On a general note, we could probably add a lot more input validation testing for the new metrics...

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
