### PR TITLE
Update docs on the compute groups feature in metric collection

### DIFF
--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -272,7 +272,7 @@ Example:
      'Recall': tensor(0.1111)}
 
 Similarly it can also reduce the amount of code required to log multiple metrics
-inside your LightningModule
+inside your LightningModule. In most cases we just have to replace ``self.log`` with ``self.log_dict``.
 
 .. testcode::
 
@@ -295,9 +295,12 @@ inside your LightningModule
         def validation_step(self, batch, batch_idx):
             logits = self(x)
             # ...
-            output = self.valid_metrics(logits, y)
+            self.valid_metrics.update(logits, y)
+
+        def validation_epoch_end(self, outputs)
             # use log_dict instead of log
             # metrics are logged with keys: val_Accuracy, val_Precision and val_Recall
+            output = self.valid_metric.compute()
             self.log_dict(output)
 
 .. note::
@@ -308,14 +311,16 @@ inside your LightningModule
 
 An additional advantage of using the ``MetricCollection`` object is that it will
 automatically try to reduce the computations needed by finding groups of metrics
-that share the same underlying metric state. If such a group of metrics is found only one
-of them is actually updated and the updated state will be broadcasted to the rest
-of the metrics within the group. In the example above, this will lead to a 2x-3x lower computational
-cost compared to disabling this feature. However, this speedup comes with a fixed cost upfront, where
-the state-groups have to be determined after the first update. This overhead can be significantly higher then gains speed-up for very
-a low number of steps (approx. up to 100) but still leads to an overall speedup for everything beyond that.
-In case the groups are known beforehand, these can also be set manually to avoid this extra cost of the
-dynamic search. See the *compute_groups* argument in the class docs below for more information on this topic.
+that share the same underlying metric state. If such a group of metrics is found
+only one of them is actually updated and the updated state will be broadcasted to
+the rest of the metrics within the group. In the example above, this will lead to
+a 2x-3x lower computational cost compared to disabling this feature in the case of
+the validation metrics where only ``update`` is called (this feature does not work
+in combination with ``forward``). However, this speedup comes with a fixed cost upfront,
+where the state-groups have to be determined after the first update. In case the groups
+are known beforehand, these can also be set manually to avoid this extra cost of the
+dynamic search. See the *compute_groups* argument in the class docs below for more
+information on this topic.
 
 .. autoclass:: torchmetrics.MetricCollection
     :noindex:

--- a/docs/source/pages/overview.rst
+++ b/docs/source/pages/overview.rst
@@ -297,7 +297,7 @@ inside your LightningModule. In most cases we just have to replace ``self.log`` 
             # ...
             self.valid_metrics.update(logits, y)
 
-        def validation_epoch_end(self, outputs)
+        def validation_epoch_end(self, outputs):
             # use log_dict instead of log
             # metrics are logged with keys: val_Accuracy, val_Precision and val_Recall
             output = self.valid_metric.compute()

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -55,6 +55,14 @@ class MetricCollection(ModuleDict):
             this behaviour. Can also be set to a list of lists of metrics for setting the compute groups yourself.
 
     .. note::
+        The compute groups feature can significatly speedup the calculation of metrics under the right conditions.
+        First, the feature is only available when calling the ``update`` method and not when calling ``forward`` method
+        due to the internal logic of ``forward`` preventing this. Secondly, since we compute groups share metric
+        states by reference, calling ``.items()``, ``.values()`` etc. on the metric collection will break this
+        reference and a copy of states are instead returned in this case (reference will be reestablished on the next
+        call to ``update``).
+
+    .. note::
         Metric collections can be nested at initilization (see last example) but the output of the collection will
         still be a single flatten dictionary combining the prefix and postfix arguments from the nested collection.
 
@@ -106,8 +114,11 @@ class MetricCollection(ModuleDict):
         ...     MeanSquaredError(),
         ...     compute_groups=[['Accuracy', 'Precision'], ['MeanSquaredError']]
         ... )
-        >>> pprint(metrics(preds, target))
+        >>> metrics.update(preds, target)
+        >>> pprint(metrics.compute())
         {'Accuracy': tensor(0.1250), 'MeanSquaredError': tensor(2.3750), 'Precision': tensor(0.0667)}
+        >>> print(metrics.compute_groups)
+        {0: ['Accuracy', 'Precision'] 1: ['MeanSquaredError']}
 
     Example (nested metric collections):
         >>> metrics = MetricCollection([
@@ -170,9 +181,6 @@ class MetricCollection(ModuleDict):
                 # only update the first member
                 m0 = getattr(self, cg[0])
                 m0.update(*args, **m0._filter_kwargs(**kwargs))
-                for i in range(1, len(cg)):  # copy over the update count
-                    mi = getattr(self, cg[i])
-                    mi._update_count = m0._update_count
             if self._state_is_copy:
                 # If we have deep copied state inbetween updates, reestablish link
                 self._compute_groups_create_state_ref()
@@ -191,7 +199,8 @@ class MetricCollection(ModuleDict):
     def _merge_compute_groups(self) -> None:
         """Iterates over the collection of metrics, checking if the state of each metric matches another.
 
-        If so, their compute groups will be merged into one
+        If so, their compute groups will be merged into one. The complexity of the method is approximately
+        ``O(number_of_metrics_in_collection ** 2)``, as all metrics need to be compared to all other metrics.
         """
         n_groups = len(self._groups)
         while True:
@@ -264,6 +273,7 @@ class MetricCollection(ModuleDict):
                         m0_state = getattr(m0, state)
                         # Determine if we just should set a reference or a full copy
                         setattr(mi, state, deepcopy(m0_state) if copy else m0_state)
+                    setattr(mi, "_update_count", deepcopy(m0._update_count) if copy else m0._update_count)
         self._state_is_copy = copy
 
     def compute(self) -> Dict[str, Any]:

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -115,7 +115,7 @@ class MetricCollection(ModuleDict):
         ...     compute_groups=[['Accuracy', 'Precision'], ['MeanSquaredError']]
         ... )
         >>> metrics.update(preds, target)
-        >>> ppprint(metrics.compute())
+        >>> pprint(metrics.compute())
         {'Accuracy': tensor(0.1250), 'MeanSquaredError': tensor(2.3750), 'Precision': tensor(0.0667)}
         >>> pprint(metrics.compute_groups)
         {0: ['Accuracy', 'Precision'] 1: ['MeanSquaredError']}

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -109,16 +109,16 @@ class MetricCollection(ModuleDict):
 
     Example (specification of compute groups):
         >>> metrics = MetricCollection(
-        ...     Accuracy(),
+        ...     Recall(num_classes=3, average='macro'),
         ...     Precision(num_classes=3, average='macro'),
         ...     MeanSquaredError(),
-        ...     compute_groups=[['Accuracy', 'Precision'], ['MeanSquaredError']]
+        ...     compute_groups=[['Recall', 'Precision'], ['MeanSquaredError']]
         ... )
         >>> metrics.update(preds, target)
         >>> pprint(metrics.compute())
-        {'Accuracy': tensor(0.1250), 'MeanSquaredError': tensor(2.3750), 'Precision': tensor(0.0667)}
+        {'MeanSquaredError': tensor(2.3750), 'Precision': tensor(0.0667), 'Recall': tensor(0.1111)}
         >>> pprint(metrics.compute_groups)
-        {0: ['Accuracy', 'Precision'] 1: ['MeanSquaredError']}
+        {0: ['Recall', 'Precision'], 1: ['MeanSquaredError']}
 
     Example (nested metric collections):
         >>> metrics = MetricCollection([

--- a/src/torchmetrics/collections.py
+++ b/src/torchmetrics/collections.py
@@ -115,9 +115,9 @@ class MetricCollection(ModuleDict):
         ...     compute_groups=[['Accuracy', 'Precision'], ['MeanSquaredError']]
         ... )
         >>> metrics.update(preds, target)
-        >>> pprint(metrics.compute())
+        >>> ppprint(metrics.compute())
         {'Accuracy': tensor(0.1250), 'MeanSquaredError': tensor(2.3750), 'Precision': tensor(0.0667)}
-        >>> print(metrics.compute_groups)
+        >>> pprint(metrics.compute_groups)
         {0: ['Accuracy', 'Precision'] 1: ['MeanSquaredError']}
 
     Example (nested metric collections):


### PR DESCRIPTION
## What does this PR do?

Fixes #1083
After looking into the issue it became clear to me that it will be near impossible to get the `compute_groups` feature from `MetricCollection` to work with calling `forward` and not just `update`. The reason being that we need to intercept the calculations inside `forward` which seems infeasible.

This PR instead updates the docs to be more clear about the expected speed-ups for this feature.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
