### PR TITLE
Fixed typo in documentation for MeanAveragePrecision

### DIFF
--- a/src/torchmetrics/detection/mean_ap.py
+++ b/src/torchmetrics/detection/mean_ap.py
@@ -226,7 +226,7 @@ class MeanAveragePrecision(Metric):
             Input format of given boxes. Supported formats are ``[`xyxy`, `xywh`, `cxcywh`]``.
         iou_type:
             Type of input (either masks or bounding-boxes) used for computing IOU.
-            Supported IOU types are ``["bboxes", "segm"]``.
+            Supported IOU types are ``["bbox", "segm"]``.
             If using ``"segm"``, masks should be provided (see :meth:`update`).
         iou_thresholds:
             IoU thresholds for evaluation. If set to ``None`` it corresponds to the stepped range ``[0.5,...,0.95]``


### PR DESCRIPTION
In the doc-string the parameter for iou_type was wrong.
