### PR TITLE
bugfix: Evaluate pred_lsum only if lsum in rouge_keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed broken clone method for classification metrics ([#1250](https://github.com/Lightning-AI/metrics/pull/1250))
+
+
 - Fixed unintentional downloading of `nltk.punkt` when `lsum` not in `rouge_keys` ([#1258](https://github.com/Lightning-AI/metrics/pull/1258))
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed broken clone method for classification metrics ([#1250](https://github.com/Lightning-AI/metrics/pull/1250))
+- Fixed unintentional downloading of `nltk.punkt` when `lsum` not in `rouge_keys` ([#1258](https://github.com/Lightning-AI/metrics/pull/1258))
 
 
 ## [0.10.0] - 2022-10-04

--- a/src/torchmetrics/functional/text/rouge.py
+++ b/src/torchmetrics/functional/text/rouge.py
@@ -315,10 +315,11 @@ def _rouge_score_update(
         result_avg: Dict[Union[int, str], List[Dict[str, Tensor]]] = {rouge_key: [] for rouge_key in rouge_keys_values}
         list_results = []
         pred = _normalize_and_tokenize_text(pred_raw, stemmer, normalizer, tokenizer)
-        pred_lsum = [
-            _normalize_and_tokenize_text(pred_sentence, stemmer, normalizer, tokenizer)
-            for pred_sentence in _split_sentence(pred_raw)
-        ]
+        if "Lsum" in rouge_keys_values:
+            pred_lsum = [
+                _normalize_and_tokenize_text(pred_sentence, stemmer, normalizer, tokenizer)
+                for pred_sentence in _split_sentence(pred_raw)
+            ]
 
         for target_raw_inner in target_raw:
             tgt = _normalize_and_tokenize_text(target_raw_inner, stemmer, normalizer, tokenizer)

--- a/src/torchmetrics/functional/text/rouge.py
+++ b/src/torchmetrics/functional/text/rouge.py
@@ -315,8 +315,7 @@ def _rouge_score_update(
         result_avg: Dict[Union[int, str], List[Dict[str, Tensor]]] = {rouge_key: [] for rouge_key in rouge_keys_values}
         list_results = []
         pred = _normalize_and_tokenize_text(pred_raw, stemmer, normalizer, tokenizer)
-        rouge_keys_values = {k.lower() for k in rouge_keys_values}
-        if "lsum" in rouge_keys_values:
+        if "Lsum" in rouge_keys_values:
             pred_lsum = [
                 _normalize_and_tokenize_text(pred_sentence, stemmer, normalizer, tokenizer)
                 for pred_sentence in _split_sentence(pred_raw)

--- a/src/torchmetrics/functional/text/rouge.py
+++ b/src/torchmetrics/functional/text/rouge.py
@@ -315,7 +315,8 @@ def _rouge_score_update(
         result_avg: Dict[Union[int, str], List[Dict[str, Tensor]]] = {rouge_key: [] for rouge_key in rouge_keys_values}
         list_results = []
         pred = _normalize_and_tokenize_text(pred_raw, stemmer, normalizer, tokenizer)
-        if "Lsum" in rouge_keys_values:
+        rouge_keys_values = {k.lower() for k in rouge_keys_values}
+        if "lsum" in rouge_keys_values:
             pred_lsum = [
                 _normalize_and_tokenize_text(pred_sentence, stemmer, normalizer, tokenizer)
                 for pred_sentence in _split_sentence(pred_raw)


### PR DESCRIPTION
Fixes #1257

Evaluate pred_lsum only if lsum in rouge_keys to avoid downloading "punkt" package from `nltk`, which raises an error when using e.g. DDP.

## What does this PR do?

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
