### PR TITLE
Fix `structural_similarity_index_measure` with autocast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed high memory usage for certain classification metrics when `average='micro'` ([#1286](https://github.com/Lightning-AI/metrics/pull/1286))
 
 
+- Fixed precision problems when `structural_similarity_index_measure` was used with autocast ([#1291](https://github.com/Lightning-AI/metrics/pull/1291))
+
+
 ## [0.10.0] - 2022-10-04
 
 ### Added

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -160,8 +160,8 @@ def _ssim_update(
     sigma_target_sq = output_list[3] - mu_target_sq
     sigma_pred_target = output_list[4] - mu_pred_target
 
-    upper = 2 * sigma_pred_target + c2
-    lower = sigma_pred_sq + sigma_target_sq + c2
+    upper = 2 * sigma_pred_target.to(dtype) + c2
+    lower = (sigma_pred_sq + sigma_target_sq).to(dtype) + c2
 
     ssim_idx_full_image = ((2 * mu_pred_target + c1) * upper) / ((mu_pred_sq + mu_target_sq + c1) * lower)
 


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/Lightning-AI/metrics/issues/1290

Found two variables in `structural_similarity_index_measure` that are necessary to have in original dtype to get the correct result within a tolerance of 1e-3. 

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
