### PR TITLE
Make LPIPS code example use the interval [-1, 1]

### DIFF
--- a/src/torchmetrics/image/lpip.py
+++ b/src/torchmetrics/image/lpip.py
@@ -78,7 +78,7 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
         >>> _ = torch.manual_seed(123)
         >>> from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
         >>> lpips = LearnedPerceptualImagePatchSimilarity(net_type='vgg')
-        >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1
+        >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1  # LPIPS needs the images to be in the [-1, 1] range.
         >>> img2 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> lpips(img1, img2)
         tensor(0.3493, grad_fn=<SqueezeBackward0>)

--- a/src/torchmetrics/image/lpip.py
+++ b/src/torchmetrics/image/lpip.py
@@ -78,8 +78,8 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
         >>> _ = torch.manual_seed(123)
         >>> from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
         >>> lpips = LearnedPerceptualImagePatchSimilarity(net_type='vgg')
-        >>> img1 = torch.rand(10, 3, 100, 100)
-        >>> img2 = torch.rand(10, 3, 100, 100)
+        >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1
+        >>> img2 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> lpips(img1, img2)
         tensor(0.3566, grad_fn=<SqueezeBackward0>)
     """

--- a/src/torchmetrics/image/lpip.py
+++ b/src/torchmetrics/image/lpip.py
@@ -78,7 +78,8 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
         >>> _ = torch.manual_seed(123)
         >>> from torchmetrics.image.lpip import LearnedPerceptualImagePatchSimilarity
         >>> lpips = LearnedPerceptualImagePatchSimilarity(net_type='vgg')
-        >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1  # LPIPS needs the images to be in the [-1, 1] range.
+        >>> # LPIPS needs the images to be in the [-1, 1] range.
+        >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> img2 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> lpips(img1, img2)
         tensor(0.3493, grad_fn=<SqueezeBackward0>)

--- a/src/torchmetrics/image/lpip.py
+++ b/src/torchmetrics/image/lpip.py
@@ -81,7 +81,7 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
         >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> img2 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> lpips(img1, img2)
-        tensor(0.3485, grad_fn=<SqueezeBackward0>)
+        tensor(0.3493, grad_fn=<SqueezeBackward0>)
     """
 
     is_differentiable: bool = True

--- a/src/torchmetrics/image/lpip.py
+++ b/src/torchmetrics/image/lpip.py
@@ -81,7 +81,7 @@ class LearnedPerceptualImagePatchSimilarity(Metric):
         >>> img1 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> img2 = (torch.rand(10, 3, 100, 100) * 2) - 1
         >>> lpips(img1, img2)
-        tensor(0.3566, grad_fn=<SqueezeBackward0>)
+        tensor(0.3485, grad_fn=<SqueezeBackward0>)
     """
 
     is_differentiable: bool = True


### PR DESCRIPTION
LPIPS input range is `[-1, 1]` by default (not `[0, 1]`). I think the example as it is now is confusing because it generates numbers in `[0, 1]`, so I changed it to be to `[-1, 1]`.