### PR TITLE
Fix slow performance for confusion matrix based metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed precision problems when `structural_similarity_index_measure` was used with autocast ([#1291](https://github.com/Lightning-AI/metrics/pull/1291))
 
 
+- Fixed slow performance for confusion matrix based metrics ([#1302](https://github.com/Lightning-AI/metrics/pull/1302))
+
+
 ## [0.10.1] - 2022-10-21
 
 ### Fixed

--- a/src/torchmetrics/utilities/data.py
+++ b/src/torchmetrics/utilities/data.py
@@ -225,8 +225,7 @@ def _bincount(x: Tensor, minlength: Optional[int] = None) -> Tensor:
         for i in range(minlength):
             output[i] = (x == i).sum()
         return output
-    z = torch.zeros(minlength, device=x.device, dtype=x.dtype)
-    return z.index_add_(0, x, torch.ones_like(x))
+    return torch.bincount(x, minlength=minlength)
 
 
 def _flexible_bincount(x: Tensor) -> Tensor:


### PR DESCRIPTION
## What does this PR do?

Fixes #1267
Fixes #1277
After the refactor the underlying `_bincount` function that does a lot of the computations for confusion matrix based metrics was changed. I did some testing at the time and everything seemed to be fine. However, for large inputs the
implementation is really slow. 

Here is a direct comparison in colab:
https://colab.research.google.com/drive/18tGZj_dPria6NSwVOIgwPXO8mJBr21kc?usp=sharing

The results:
![image](https://user-images.githubusercontent.com/24896311/198999510-5d6e2dff-aa3c-4081-ac97-c0a115deb633.png)
The TLDR:
* Regardless of batch size the new implementation is approx 2x slower on cpu
* For batch size 100 the new implementation is approx ~4x FASTER on gpu
* For batch size 10.000 the new implementation is approx ~30x SLOWER on gpu

The simple fix currently in this PR is to change it back to the old implementation. The alternative is that we have something like this in the code:
```python
def _bincount(x, minlength=minlength):
    ...
    if len(x) > N or not x.is_cuda:
        return torch.bincount(x, minlength=minlenght)
    else:
        z = torch.zeros(minlength, device=x.device, dtype=x.dtype)
        return z.index_add_(0, x, torch.ones_like(x))
```
where we have to set N based on some experimentation.
@Borda, @justusschock opinions?

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
