### PR TITLE
Fix autocast with spearman metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed precision problems when `structural_similarity_index_measure` was used with autocast ([#1291](https://github.com/Lightning-AI/metrics/pull/1291))
 
 
+- Fixed restrictive dtype checking in `spearman_corrcoef` when used with autocast ([#1303](https://github.com/Lightning-AI/metrics/pull/1303))
+
+
 ## [0.10.1] - 2022-10-21
 
 ### Fixed

--- a/src/torchmetrics/functional/regression/spearman.py
+++ b/src/torchmetrics/functional/regression/spearman.py
@@ -62,10 +62,9 @@ def _spearman_corrcoef_update(preds: Tensor, target: Tensor, num_outputs: int) -
         target: Ground truth tensor
     """
 
-    if preds.dtype != target.dtype:
+    if not (preds.is_floating_point() and target.is_floating_point()):
         raise TypeError(
-            "Expected `preds` and `target` to have the same data type."
-            f" Got preds: {preds.dtype} and target: {target.dtype}."
+            "Expected `preds` and `target` both to be floating point tensors, but got {pred.dtype} and {target.dtype}"
         )
     _check_same_shape(preds, target)
     if preds.ndim > 2 or target.ndim > 2:

--- a/tests/unittests/regression/test_spearman.py
+++ b/tests/unittests/regression/test_spearman.py
@@ -134,6 +134,9 @@ class TestSpearmanCorrCoef(MetricTester):
 
 def test_error_on_different_shape():
     metric = SpearmanCorrCoef(num_outputs=1)
+    with pytest.raises(TypeError, match="Expected `preds` and `target` both to be floating point tensors.*"):
+        metric(torch.randint(5, (100,)), torch.randn(100))
+
     with pytest.raises(RuntimeError, match="Predictions and targets are expected to have the same shape"):
         metric(torch.randn(100), torch.randn(50))
 


### PR DESCRIPTION
## What does this PR do?

Fixes #1294 
Makes checking of dtypes less restrictive for spearman metric so it will also work when used together with `torch.cuda.amp.autocast`. 

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
