### PR TITLE
fix docs for 1 being best

### DIFF
--- a/src/torchmetrics/text/wip.py
+++ b/src/torchmetrics/text/wip.py
@@ -24,7 +24,7 @@ class WordInfoPreserved(Metric):
     r"""Word Information Preserved (WIP_) is a metric of the performance of an automatic speech recognition system.
     This value indicates the percentage of words that were correctly predicted between a set of ground-truth
     sentences and a set of hypothesis sentences. The higher the value, the better the performance of the ASR system
-    with a WordInfoPreserved of 0 being a perfect score. Word Information Preserved rate can then be computed as:
+    with a WordInfoPreserved of 1 being a perfect score. Word Information Preserved rate can then be computed as:
 
     .. math::
         wip = \frac{C}{N} + \frac{C}{P}


### PR DESCRIPTION
Update `text/wip.py` --> Just fixed doc (best score is 1 not 0)
