### PR TITLE
Fix bug in metric tracker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed restrictive dtype checking in `spearman_corrcoef` when used with autocast ([#1303](https://github.com/Lightning-AI/metrics/pull/1303))
 
 
+- Fixed bug in `Metrictracker.best_metric` when `return_step=False` ([#1306](https://github.com/Lightning-AI/metrics/pull/1306))
+
+
 ## [0.10.1] - 2022-10-21
 
 ### Fixed

--- a/tests/unittests/wrappers/test_tracker.py
+++ b/tests/unittests/wrappers/test_tracker.py
@@ -126,6 +126,9 @@ def test_tracker(base_metric, metric_input, maximize):
         assert val != 0.0
         assert idx in list(range(5))
 
+    val2 = tracker.best_metric(return_step=False)
+    assert val == val2
+
 
 @pytest.mark.parametrize(
     "base_metric",


### PR DESCRIPTION
## What does this PR do?

Fixes #1304 
Wrong variable was returned in the `return_step=False` case due to confusing variable naming.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
