### PR TITLE
Prevent iteration over metrics

### DIFF
--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -858,6 +858,9 @@ class Metric(Module, ABC):
     def __getnewargs__(self) -> Tuple:
         return (Metric.__str__(self),)
 
+    def __iter__(self):
+        raise NotImplementedError("Metrics does not support iteration.")
+
 
 def _neg(x: Tensor) -> Tensor:
     return -torch.abs(x)

--- a/tests/unittests/bases/test_metric.py
+++ b/tests/unittests/bases/test_metric.py
@@ -464,3 +464,10 @@ def test_custom_availability_check_and_sync_fn():
     acc.compute()
     dummy_availability_check.assert_called_once()
     assert dummy_dist_sync_fn.call_count == 4  # tp, fp, tn, fn
+
+
+def test_no_iteration_allowed():
+    metric = DummyMetric()
+    with pytest.raises(NotImplementedError, match="Metrics does not support iteration."):
+        for m in metric:
+            continue


### PR DESCRIPTION
## What does this PR do?

Fixes #1319 
Prevents users from accidentally end up in a infinite loop if they try to iterate over a single metric.
The reason currently is that we implement the `__getitem__` method to create compositional metrics for indexing and we therefore need to explicit prevent iteration.

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
