### PR TITLE
Fix doc in accuracy module

### DIFF
--- a/src/torchmetrics/classification/accuracy.py
+++ b/src/torchmetrics/classification/accuracy.py
@@ -109,6 +109,7 @@ class BinaryAccuracy(BinaryStatScores):
     full_state_update: bool = False
 
     def compute(self) -> Tensor:
+        """Computes accuracy based on inputs passed in to ``update`` previously."""
         tp, fp, tn, fn = self._final_state()
         return _accuracy_reduce(tp, fp, tn, fn, average="binary", multidim_average=self.multidim_average)
 
@@ -214,6 +215,7 @@ class MulticlassAccuracy(MulticlassStatScores):
     full_state_update: bool = False
 
     def compute(self) -> Tensor:
+        """Computes accuracy based on inputs passed in to ``update`` previously."""
         tp, fp, tn, fn = self._final_state()
         return _accuracy_reduce(tp, fp, tn, fn, average=self.average, multidim_average=self.multidim_average)
 
@@ -317,6 +319,7 @@ class MultilabelAccuracy(MultilabelStatScores):
     full_state_update: bool = False
 
     def compute(self) -> Tensor:
+        """Computes accuracy based on inputs passed in to ``update`` previously."""
         tp, fp, tn, fn = self._final_state()
         return _accuracy_reduce(
             tp, fp, tn, fn, average=self.average, multidim_average=self.multidim_average, multilabel=True


### PR DESCRIPTION
## What does this PR do?

This fixes an inheritance problem in the docstring for the _compute_ method for 3 classes of the module _classification.accuracy_: _BinaryAccuracy_, _MulticlassAccuracy_ and _MultilabelAccuracy_ . The current docstring for the compute method is pulled from parent classes from the module _classification.stat_scores (cf [doc link](https://torchmetrics.readthedocs.io/en/stable/classification/accuracy.html#binaryaccuracy)):
```
Computes the final statistics.

        Returns:
            The metric returns a tensor of shape ``(..., 5)``, where the last dimension corresponds
            to ``[tp, fp, tn, fn, sup]`` (``sup`` stands for support and equals ``tp + fn``). The shape
            depends on ``average`` and ``multidim_average`` parameters:

            - If ``multidim_average`` is set to ``global``
            - If ``average='micro'/'macro'/'weighted'``, the shape will be ``(5,)``
            - If ``average=None/'none'``, the shape will be ``(C, 5)``
            - If ``multidim_average`` is set to ``samplewise``
            - If ``average='micro'/'macro'/'weighted'``, the shape will be ``(N, 5)``
            - If ``average=None/'none'``, the shape will be ``(N, C, 5)``
```

This is incorrect, the compute method actually returns the reduced accuracy.

This comes  from a default settings of sphinx (autodoc_inherit_docstrings is set to True): if a method has no docstring defined, sphinx pull the docstring of the parent class. In this case it leads to wrong documentation since the parent classes returns stats instead of a metric.

This PR does not modify the sphinx settings since it could creates a lot of problem elsewhere. It adds a minimal docstring to the _compute_ method to prevent inheritance (the format of the metric is well defined in the class docstring).

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
