### PR TITLE
Fix aggregation broadcast & small doc fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,15 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed precision bug in `pairwise_euclidean_distance` ([#1352](https://github.com/Lightning-AI/metrics/pull/1352))
 
-
 ## [0.10.3] - 2022-11-16
 
 ### Fixed
 
 - Fixed bug in `Metrictracker.best_metric` when `return_step=False` ([#1306](https://github.com/Lightning-AI/metrics/pull/1306))
 - Fixed bug to prevent users from going into an infinite loop if trying to iterate of a single metric ([#1320](https://github.com/Lightning-AI/metrics/pull/1320))
-- Fixed bug in `Metrictracker.best_metric` when `return_step=False` ([#1306](https://github.com/Lightning-AI/metrics/pull/1306))
-
 
 ## [0.10.2] - 2022-10-31
 

--- a/src/torchmetrics/aggregation.py
+++ b/src/torchmetrics/aggregation.py
@@ -348,14 +348,7 @@ class MeanMetric(BaseAggregator):
         if value.numel() == 0:
             return
         # broadcast weight to value shape
-        if hasattr(torch, "broadcast_to"):
-            weight = torch.broadcast_to(weight, value.shape)
-        else:
-            if weight.shape == ():
-                weight = torch.ones_like(value) * weight
-            if weight.shape != value.shape:
-                raise ValueError("Broadcasting not supported on PyTorch <1.8")
-
+        weight = torch.broadcast_to(weight, value.shape)
         self.value += (value * weight).sum()
         self.weight += weight.sum()
 

--- a/src/torchmetrics/audio/pesq.py
+++ b/src/torchmetrics/audio/pesq.py
@@ -34,11 +34,11 @@ class PerceptualEvaluationSpeechQuality(Metric):
     As input to ``forward`` and ``update`` the metric accepts the following input
 
     - ``preds`` (:class:`~torch.Tensor`): float tensor with shape ``(...,time)``
-    - ``target`` (: :class:`~torch.Tensor`): float tensor with shape ``(...,time)``
+    - ``target`` (:class:`~torch.Tensor`): float tensor with shape ``(...,time)``
 
     As output of `forward` and `compute` the metric returns the following output
 
-    - ``pesq`` (: :class:`~torch.Tensor`): float tensor with shape ``(...,)`` of PESQ value per sample
+    - ``pesq`` (:class:`~torch.Tensor`): float tensor with shape ``(...,)`` of PESQ value per sample
 
     .. note:: using this metrics requires you to have ``pesq`` install. Either install as ``pip install
         torchmetrics[audio]`` or ``pip install pesq``. ``pesq`` will compile with your currently

--- a/src/torchmetrics/audio/pit.py
+++ b/src/torchmetrics/audio/pit.py
@@ -27,11 +27,11 @@ class PermutationInvariantTraining(Metric):
     As input to ``forward`` and ``update`` the metric accepts the following input
 
     - ``preds`` (:class:`~torch.Tensor`): float tensor with shape ``(batch_size,num_speakers,...)``
-    - ``target`` (: :class:`~torch.Tensor`): float tensor with shape ``(batch_size,num_speakers,...)``
+    - ``target`` (:class:`~torch.Tensor`): float tensor with shape ``(batch_size,num_speakers,...)``
 
     As output of `forward` and `compute` the metric returns the following output
 
-    - ``pesq`` (: :class:`~torch.Tensor`): float scalar tensor with average PESQ value over samples
+    - ``pesq`` (:class:`~torch.Tensor`): float scalar tensor with average PESQ value over samples
 
     Args:
         metric_func:

--- a/src/torchmetrics/audio/sdr.py
+++ b/src/torchmetrics/audio/sdr.py
@@ -28,11 +28,11 @@ class SignalDistortionRatio(Metric):
     As input to ``forward`` and ``update`` the metric accepts the following input
 
     - ``preds`` (:class:`~torch.Tensor`): float tensor with shape ``(...,time)``
-    - ``target`` (: :class:`~torch.Tensor`): float tensor with shape ``(...,time)``
+    - ``target`` (:class:`~torch.Tensor`): float tensor with shape ``(...,time)``
 
     As output of `forward` and `compute` the metric returns the following output
 
-    - ``sdr`` (: :class:`~torch.Tensor`): float scalar tensor with average SDR value over samples
+    - ``sdr`` (:class:`~torch.Tensor`): float scalar tensor with average SDR value over samples
 
     .. note:
         The metric currently does not seem to work with Pytorch v1.11 and specific GPU hardware.

--- a/src/torchmetrics/audio/snr.py
+++ b/src/torchmetrics/audio/snr.py
@@ -31,11 +31,11 @@ class SignalNoiseRatio(Metric):
     As input to `forward` and `update` the metric accepts the following input
 
     - ``preds`` (:class:`~torch.Tensor`): float tensor with shape ``(...,time)``
-    - ``target`` (: :class:`~torch.Tensor`): float tensor with shape ``(...,time)``
+    - ``target`` (:class:`~torch.Tensor`): float tensor with shape ``(...,time)``
 
     As output of `forward` and `compute` the metric returns the following output
 
-    - ``snr`` (: :class:`~torch.Tensor`): float scalar tensor with average SNR value over samples
+    - ``snr`` (:class:`~torch.Tensor`): float scalar tensor with average SNR value over samples
 
     Args:
         zero_mean: if to zero mean target and preds or not

--- a/src/torchmetrics/audio/stoi.py
+++ b/src/torchmetrics/audio/stoi.py
@@ -39,11 +39,11 @@ class ShortTimeObjectiveIntelligibility(Metric):
     As input to `forward` and `update` the metric accepts the following input
 
     - ``preds`` (:class:`~torch.Tensor`): float tensor with shape ``(...,time)``
-    - ``target`` (: :class:`~torch.Tensor`): float tensor with shape ``(...,time)``
+    - ``target`` (:class:`~torch.Tensor`): float tensor with shape ``(...,time)``
 
     As output of `forward` and `compute` the metric returns the following output
 
-    - ``stoi`` (: :class:`~torch.Tensor`): float scalar tensor
+    - ``stoi`` (:class:`~torch.Tensor`): float scalar tensor
 
     .. note:: using this metrics requires you to have ``pystoi`` install. Either install as ``pip install
         torchmetrics[audio]`` or ``pip install pystoi``.

--- a/src/torchmetrics/functional/text/perplexity.py
+++ b/src/torchmetrics/functional/text/perplexity.py
@@ -117,7 +117,7 @@ def perplexity(preds: Tensor, target: Tensor, ignore_index: Optional[int] = None
 
     Args:
         preds:
-            Probabilities assigned to each token in a sequence with shape [batch_size, seq_len, vocab_size].
+            Log probabilities assigned to each token in a sequence with shape [batch_size, seq_len, vocab_size].
         target:
             Ground truth values with a shape [batch_size, seq_len].
         ignore_index:


### PR DESCRIPTION
## What does this PR do?

Just a collection of small fixes:
* Fixes docstring for `perplexity` pointed out in https://github.com/Lightning-AI/metrics/issues/1366
* Fix double instance in changelog
* in `aggregation.py` removes a check that is irrelevant after we set min pytorch to v1.8 in PR https://github.com/Lightning-AI/metrics/pull/1263
* fixes small error in audio documentation coming from PR https://github.com/Lightning-AI/metrics/pull/1360 where an addtional `:` was wrongly added

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
