### PR TITLE
Fix wrong header for Jaccard Index

### DIFF
--- a/docs/source/classification/jaccard_index.rst
+++ b/docs/source/classification/jaccard_index.rst
@@ -10,8 +10,8 @@ Jaccard Index
 Module Interface
 ________________
 
-CohenKappa
-^^^^^^^^^^
+JaccardIndex
+^^^^^^^^^^^^
 
 .. autoclass:: torchmetrics.JaccardIndex
     :noindex:


### PR DESCRIPTION
Changed `CohenKappa` to `JaccardIndex`

Appears to have been introduced here: https://github.com/Lightning-AI/metrics/pull/1143/files#diff-c78d9cdc33a4cc6498dedc6a4cb81427f583b268fd857c0b18edc27f65fcb4fd