### PR TITLE
Update retrieval docs

### DIFF
--- a/docs/source/retrieval/fall_out.rst
+++ b/docs/source/retrieval/fall_out.rst
@@ -14,6 +14,7 @@ ________________
 
 .. autoclass:: torchmetrics.RetrievalFallOut
     :noindex:
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________

--- a/docs/source/retrieval/hit_rate.rst
+++ b/docs/source/retrieval/hit_rate.rst
@@ -12,6 +12,7 @@ ________________
 
 .. autoclass:: torchmetrics.RetrievalHitRate
     :noindex:
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________

--- a/docs/source/retrieval/map.rst
+++ b/docs/source/retrieval/map.rst
@@ -14,6 +14,7 @@ ________________
 
 .. autoclass:: torchmetrics.RetrievalMAP
     :noindex:
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________

--- a/docs/source/retrieval/mrr.rst
+++ b/docs/source/retrieval/mrr.rst
@@ -14,6 +14,7 @@ ________________
 
 .. autoclass:: torchmetrics.RetrievalMRR
     :noindex:
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________

--- a/docs/source/retrieval/normalized_dcg.rst
+++ b/docs/source/retrieval/normalized_dcg.rst
@@ -14,6 +14,7 @@ ________________
 
 .. autoclass:: torchmetrics.RetrievalNormalizedDCG
     :noindex:
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________

--- a/docs/source/retrieval/precision.rst
+++ b/docs/source/retrieval/precision.rst
@@ -14,6 +14,7 @@ ________________
 
 .. autoclass:: torchmetrics.RetrievalPrecision
     :noindex:
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________

--- a/docs/source/retrieval/precision_recall_curve.rst
+++ b/docs/source/retrieval/precision_recall_curve.rst
@@ -14,6 +14,7 @@ ________________
 
 .. autoclass:: torchmetrics.RetrievalPrecisionRecallCurve
     :noindex:
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________

--- a/docs/source/retrieval/r_precision.rst
+++ b/docs/source/retrieval/r_precision.rst
@@ -14,6 +14,7 @@ ________________
 
 .. autoclass:: torchmetrics.RetrievalRPrecision
     :noindex:
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________

--- a/docs/source/retrieval/recall.rst
+++ b/docs/source/retrieval/recall.rst
@@ -14,6 +14,7 @@ ________________
 
 .. autoclass:: torchmetrics.RetrievalRecall
     :noindex:
+    :exclude-members: update, compute
 
 Functional Interface
 ____________________


### PR DESCRIPTION
## What does this PR do?

Fixes retrieval docs, as a part of fixes in #1365 

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

# Some Notes

I didn't find any I/O tensor info, references, or shape info that had to be reworked, so just excluding update/compute was needed