### PR TITLE
Add missing dtype check in PrecisionRecallCurve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed type checking on the `maximize` parameter at the initialization of `MetricTracker` ([#1428](https://github.com/Lightning-AI/metrics/issues/1428))
 
 
-- Fix checking for `nltk.punkt` in `RougeScore` if a machine is not online ([#1456](https://github.com/Lightning-AI/metrics/pull/1456))
-
+- Fix dtype checking in `PrecisionRecallCurve` for `target` tensor ([#1457](https://github.com/Lightning-AI/metrics/pull/1457))
 
 ## [0.11.0] - 2022-11-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed type checking on the `maximize` parameter at the initialization of `MetricTracker` ([#1428](https://github.com/Lightning-AI/metrics/issues/1428))
 
 
+- Fix checking for `nltk.punkt` in `RougeScore` if a machine is not online ([#1456](https://github.com/Lightning-AI/metrics/pull/1456))
+
+
 ## [0.11.0] - 2022-11-30
 
 ### Added

--- a/src/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/src/torchmetrics/functional/classification/precision_recall_curve.py
@@ -342,7 +342,7 @@ def _multiclass_precision_recall_curve_tensor_validation(
         )
     if target.is_floating_point():
         raise ValueError(
-            "Expected argument `target` to be an int or long tensor, but got tensor with dtype {target.dtype}"
+            f"Expected argument `target` to be an int or long tensor, but got tensor with dtype {target.dtype}"
         )
     if not preds.is_floating_point():
         raise ValueError(f"Expected `preds` to be a float tensor, but got {preds.dtype}")

--- a/src/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/src/torchmetrics/functional/classification/precision_recall_curve.py
@@ -132,6 +132,12 @@ def _binary_precision_recall_curve_tensor_validation(
     """
     _check_same_shape(preds, target)
 
+    if target.is_floating_point():
+        raise ValueError(
+            "Expected argument `target` to be an int or long tensor with ground truth labels"
+            f" but got tensor with dtype {target.dtype}"
+        )
+
     if not preds.is_floating_point():
         raise ValueError(
             "Expected argument `preds` to be an floating tensor with probability/logit scores,"
@@ -333,6 +339,10 @@ def _multiclass_precision_recall_curve_tensor_validation(
     if not preds.ndim == target.ndim + 1:
         raise ValueError(
             f"Expected `preds` to have one more dimension than `target` but got {preds.ndim} and {target.ndim}"
+        )
+    if target.is_floating_point():
+        raise ValueError(
+            "Expected argument `target` to be an int or long tensor, but got tensor with dtype {target.dtype}"
         )
     if not preds.is_floating_point():
         raise ValueError(f"Expected `preds` to be a float tensor, but got {preds.dtype}")
@@ -622,7 +632,7 @@ def _multilabel_precision_recall_curve_update(
     len_t = len(thresholds)
     # num_samples x num_labels x num_thresholds
     preds_t = (preds.unsqueeze(-1) >= thresholds.unsqueeze(0).unsqueeze(0)).long()
-    unique_mapping = preds_t + 2 * target.unsqueeze(-1)
+    unique_mapping = preds_t + 2 * target.unsqueeze(-1)  # target.long().unsqueeze(-1)
     unique_mapping += 4 * torch.arange(num_labels, device=preds.device).unsqueeze(0).unsqueeze(-1)
     unique_mapping += 4 * num_labels * torch.arange(len_t, device=preds.device)
     unique_mapping = unique_mapping[unique_mapping >= 0]

--- a/src/torchmetrics/functional/classification/precision_recall_curve.py
+++ b/src/torchmetrics/functional/classification/precision_recall_curve.py
@@ -632,7 +632,7 @@ def _multilabel_precision_recall_curve_update(
     len_t = len(thresholds)
     # num_samples x num_labels x num_thresholds
     preds_t = (preds.unsqueeze(-1) >= thresholds.unsqueeze(0).unsqueeze(0)).long()
-    unique_mapping = preds_t + 2 * target.unsqueeze(-1)  # target.long().unsqueeze(-1)
+    unique_mapping = preds_t + 2 * target.unsqueeze(-1)
     unique_mapping += 4 * torch.arange(num_labels, device=preds.device).unsqueeze(0).unsqueeze(-1)
     unique_mapping += 4 * num_labels * torch.arange(len_t, device=preds.device)
     unique_mapping = unique_mapping[unique_mapping >= 0]

--- a/src/torchmetrics/functional/text/rouge.py
+++ b/src/torchmetrics/functional/text/rouge.py
@@ -50,11 +50,14 @@ def _is_internet_connection():
 
 
 def _ensure_nltk_punkt_is_downloaded():
-    """Check whether `nltk` `punkt` is downloaded. If not, try to download if a machine is connected to the internet."""
+    """Check whether `nltk` `punkt` is downloaded.
+
+    If not, try to download if a machine is connected to the internet.
+    """
     import nltk
 
     try:
-        nltk.data.find('tokenizers/punkt.zip')
+        nltk.data.find("tokenizers/punkt.zip")
     except LookupError:
         if _is_internet_connection():
             nltk.download("punkt", quiet=True, force=False)

--- a/src/torchmetrics/functional/text/rouge.py
+++ b/src/torchmetrics/functional/text/rouge.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
-import urllib.request
 from collections import Counter
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
-from urllib.request import HTTPError
 
 import torch
 from torch import Tensor, tensor
@@ -41,40 +39,13 @@ ALLOWED_ROUGE_KEYS: Dict[str, Union[int, str]] = {
 ALLOWED_ACCUMULATE_VALUES = ("avg", "best")
 
 
-def _is_internet_connection() -> bool:
-    try:
-        urllib.request.urlopen("https://torchmetrics.readthedocs.io/")
-        return True
-    except HTTPError:
-        return False
-
-
-def _ensure_nltk_punkt_is_downloaded() -> None:
-    """Check whether `nltk` `punkt` is downloaded.
-
-    If not, try to download if a machine is connected to the internet.
-    """
-    import nltk
-
-    try:
-        nltk.data.find("tokenizers/punkt.zip")
-    except LookupError:
-        if _is_internet_connection():
-            nltk.download("punkt", quiet=True, force=False)
-        else:
-            raise OSError(
-                "`nltk` resource `punkt` is not available on a disk and cannot be downloaded as a machine is not "
-                "connected to the internet."
-            )
-
-
 def _split_sentence(x: str) -> Sequence[str]:
     """The sentence is split to get rougeLsum scores matching published rougeL scores for BART and PEGASUS."""
     if not _NLTK_AVAILABLE:
         raise ModuleNotFoundError("ROUGE-Lsum calculation requires that `nltk` is installed. Use `pip install nltk`.")
     import nltk
 
-    _ensure_nltk_punkt_is_downloaded()
+    nltk.download("punkt", quiet=True, force=False)
 
     re.sub("<n>", "", x)  # remove pegasus newline char
     return nltk.sent_tokenize(x)

--- a/src/torchmetrics/functional/text/rouge.py
+++ b/src/torchmetrics/functional/text/rouge.py
@@ -41,7 +41,7 @@ ALLOWED_ROUGE_KEYS: Dict[str, Union[int, str]] = {
 ALLOWED_ACCUMULATE_VALUES = ("avg", "best")
 
 
-def _is_internet_connection():
+def _is_internet_connection() -> bool:
     try:
         urllib.request.urlopen("https://torchmetrics.readthedocs.io/")
         return True
@@ -49,7 +49,7 @@ def _is_internet_connection():
         return False
 
 
-def _ensure_nltk_punkt_is_downloaded():
+def _ensure_nltk_punkt_is_downloaded() -> None:
     """Check whether `nltk` `punkt` is downloaded.
 
     If not, try to download if a machine is connected to the internet.

--- a/src/torchmetrics/functional/text/rouge.py
+++ b/src/torchmetrics/functional/text/rouge.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import re
+import urllib.request
 from collections import Counter
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from urllib.request import HTTPError
 
 import torch
 from torch import Tensor, tensor
@@ -39,13 +41,37 @@ ALLOWED_ROUGE_KEYS: Dict[str, Union[int, str]] = {
 ALLOWED_ACCUMULATE_VALUES = ("avg", "best")
 
 
+def _is_internet_connection():
+    try:
+        urllib.request.urlopen("https://torchmetrics.readthedocs.io/")
+        return True
+    except HTTPError:
+        return False
+
+
+def _ensure_nltk_punkt_is_downloaded():
+    """Check whether `nltk` `punkt` is downloaded. If not, try to download if a machine is connected to the internet."""
+    import nltk
+
+    try:
+        nltk.data.find('tokenizers/punkt.zip')
+    except LookupError:
+        if _is_internet_connection():
+            nltk.download("punkt", quiet=True, force=False)
+        else:
+            raise OSError(
+                "`nltk` resource `punkt` is not available on a disk and cannot be downloaded as a machine is not "
+                "connected to the internet."
+            )
+
+
 def _split_sentence(x: str) -> Sequence[str]:
     """The sentence is split to get rougeLsum scores matching published rougeL scores for BART and PEGASUS."""
     if not _NLTK_AVAILABLE:
         raise ModuleNotFoundError("ROUGE-Lsum calculation requires that `nltk` is installed. Use `pip install nltk`.")
     import nltk
 
-    nltk.download("punkt", quiet=True, force=False)
+    _ensure_nltk_punkt_is_downloaded()
 
     re.sub("<n>", "", x)  # remove pegasus newline char
     return nltk.sent_tokenize(x)

--- a/tests/unittests/classification/test_precision_recall_curve.py
+++ b/tests/unittests/classification/test_precision_recall_curve.py
@@ -132,6 +132,16 @@ class TestBinaryPrecisionRecallCurve(MetricTester):
             assert torch.allclose(r1, r2)
             assert torch.allclose(t1, t2)
 
+    def test_binary_error_on_wrong_dtypes(self, input):
+        """Test that error are raised on wrong dtype."""
+        preds, target = input
+
+        with pytest.raises(ValueError, match="Expected argument `target` to be an int or long tensor with ground.*"):
+            binary_precision_recall_curve(preds[0], target[0].to(torch.float32))
+
+        with pytest.raises(ValueError, match="Expected argument `preds` to be an floating tensor with probability.*"):
+            binary_precision_recall_curve(preds[0].long(), target[0])
+
 
 def _sklearn_precision_recall_curve_multiclass(preds, target, ignore_index=None):
     preds = np.moveaxis(preds.numpy(), 1, -1).reshape((-1, preds.shape[1]))
@@ -243,6 +253,16 @@ class TestMulticlassPrecisionRecallCurve(MetricTester):
                 assert torch.allclose(r1[i], r2[i])
                 assert torch.allclose(t1[i], t2)
 
+    def test_multiclass_error_on_wrong_dtypes(self, input):
+        """Test that error are raised on wrong dtype."""
+        preds, target = input
+
+        with pytest.raises(ValueError, match="Expected argument `target` to be an int or long tensor, but got.*"):
+            multiclass_precision_recall_curve(preds[0], target[0].to(torch.float32), num_classes=NUM_CLASSES)
+
+        with pytest.raises(ValueError, match="Expected `preds` to be a float tensor, but got.*"):
+            multiclass_precision_recall_curve(preds[0].long(), target[0], num_classes=NUM_CLASSES)
+
 
 def _sklearn_precision_recall_curve_multilabel(preds, target, ignore_index=None):
     precision, recall, thresholds = [], [], []
@@ -344,6 +364,16 @@ class TestMultilabelPrecisionRecallCurve(MetricTester):
                 assert torch.allclose(p1[i], p2[i])
                 assert torch.allclose(r1[i], r2[i])
                 assert torch.allclose(t1[i], t2)
+
+    def test_multilabel_error_on_wrong_dtypes(self, input):
+        """Test that error are raised on wrong dtype."""
+        preds, target = input
+
+        with pytest.raises(ValueError, match="Expected argument `target` to be an int or long tensor with ground.*"):
+            multilabel_precision_recall_curve(preds[0], target[0].to(torch.float32), num_labels=NUM_CLASSES)
+
+        with pytest.raises(ValueError, match="Expected argument `preds` to be an floating tensor with probability.*"):
+            multilabel_precision_recall_curve(preds[0].long(), target[0], num_labels=NUM_CLASSES)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Fixes #1443 
Add missing dtype check on the `target` tensor for PR-curve metric, which leads to unwanted errors later in the code.

## Before submitting

- [x] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?

Make sure you had fun coding 🙃
