### PR TITLE
Fix type hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix compatibility between XLA in `_bincount` function ([#1471](https://github.com/Lightning-AI/metrics/pull/1471))
+- Fixed compatibility between XLA in `_bincount` function ([#1471](https://github.com/Lightning-AI/metrics/pull/1471))
 
 
--
+- Fixed type hints in methods belonging to `MetricTracker` wrapper ([#1472](https://github.com/Lightning-AI/metrics/pull/1472))
 
 
 ## [0.11.1] - 2023-01-30

--- a/docs/source/wrappers/metric_tracker.rst
+++ b/docs/source/wrappers/metric_tracker.rst
@@ -14,3 +14,4 @@ ________________
 
 .. autoclass:: torchmetrics.MetricTracker
     :noindex:
+    :exclude-members: update, compute

--- a/src/torchmetrics/wrappers/tracker.py
+++ b/src/torchmetrics/wrappers/tracker.py
@@ -134,7 +134,7 @@ class MetricTracker(ModuleList):
         self._check_for_increment("compute")
         return self[-1].compute()
 
-    def compute_all(self) -> Tensor:
+    def compute_all(self) -> Union[Tensor, Dict[str, Tensor]]:
         """Compute the metric value for all tracked metrics."""
         self._check_for_increment("compute_all")
         # The i!=0 accounts for the self._base_metric should be ignored

--- a/src/torchmetrics/wrappers/tracker.py
+++ b/src/torchmetrics/wrappers/tracker.py
@@ -158,10 +158,10 @@ class MetricTracker(ModuleList):
     ) -> Union[
         None,
         float,
-        Tuple[int, float],
+        Tuple[float, int],
         Tuple[None, None],
         Dict[str, Union[float, None]],
-        Tuple[Dict[str, Union[int, None]], Dict[str, Union[float, None]]],
+        Tuple[Dict[str, Union[float, None]], Dict[str, Union[int, None]]],
     ]:
         """Returns the highest metric out of all tracked.
 

--- a/tests/unittests/wrappers/test_tracker.py
+++ b/tests/unittests/wrappers/test_tracker.py
@@ -170,7 +170,7 @@ def test_best_metric_for_not_well_defined_metric_collection(base_metric):
             assert best is None
 
     with pytest.warns(UserWarning, match="Encountered the following error when trying to get the best metric.*"):
-        idx, best = tracker.best_metric(return_step=True)
+        best, idx = tracker.best_metric(return_step=True)
 
         if isinstance(best, dict):
             assert best["MulticlassAccuracy"] is not None


### PR DESCRIPTION
## What does this PR do?

This PR fixes some type hints in MetricTracker, which do not correspond to the possible return types of the methods.
It also fixes in a test a confusion in the order of the tuple (value, index) returned by MetricTracker.best_metric (the order now matches the type hint and the type hint now matches the doc).

## Before submitting

- [ ] Was this **discussed/approved** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**? => No need
- [x] Did you write any new **necessary tests**? => No need

## PR review

## Did you have fun?
Yes!
