### PR TITLE
Update exact_match.py

### DIFF
--- a/src/torchmetrics/functional/classification/exact_match.py
+++ b/src/torchmetrics/functional/classification/exact_match.py
@@ -232,7 +232,7 @@ def exact_match(
     if task == "multiclass":
         assert num_classes is not None
         return multiclass_exact_match(preds, target, num_classes, multidim_average, ignore_index, validate_args)
-    if task == "multilalbe":
+    if task == "multilabel":
         assert num_labels is not None
         return multilabel_exact_match(
             preds, target, num_labels, threshold, multidim_average, ignore_index, validate_args


### PR DESCRIPTION
Typo in line 235. Changed `multilalbe` to `multilalbe`.

## What does this PR do?

Small typo for argument `task` for the `exact_match` metric. 
Identify multi-label classification task properly by changing `multilalbe` to `multilalbe`. 

Fixes #\<issue_number>

## Before submitting

- [X] Was this **discussed/approved** via a Github issue? (no need for typos [THIS] and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure to **update the docs**? (None required, just ypo)
- [] Did you write any new **necessary tests**?

## PR review

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Yes.

Make sure you had fun coding 🙃
