### PR TITLE
Fix broken `make-docs` CI

### DIFF
--- a/docs/source/pages/implement.rst
+++ b/docs/source/pages/implement.rst
@@ -125,7 +125,7 @@ Wanting to contribute the metric you have implemented? Great, we are always open
 as long as they serve a general purpose. However, to keep all our metrics consistent we request that the implementation
 and tests gets formatted in the following way:
 
-1. Start by reading our `contribution guidelines <https://torchmetrics.readthedocs.io//en/latest/generated/CONTRIBUTING.html>`_.
+1. Start by reading our `contribution guidelines <https://torchmetrics.readthedocs.io/en/latest/generated/CONTRIBUTING.html>`_.
 2. First implement the functional backend. This takes cares of all the logic that goes into the metric. The code should
    be put into a single file placed under ``torchmetrics/functional/"domain"/"new_metric".py`` where ``domain`` is the type of
    metric (classification, regression, nlp etc) and ``new_metric`` is the name of the metric. In this file, there should be the


### PR DESCRIPTION
## What does this PR do?

Fixes #\<issue_number>

Make-docs CI is currently failing on all PR with:
```
( pages/implement: line  128) broken    https://torchmetrics.readthedocs.io//en/latest/generated/CONTRIBUTING.html - Exceeded 30 redirects.
```
not sure why this has suddenly started to fail but there seems to be an extra `/` between `torchmetrics.readthedocs.io`  and `en` in the link. Removing this makes the CI pass.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
