### PR TITLE
Refactoring is in doctests for slow downloads

### DIFF
--- a/.azure/gpu-pipeline.yml
+++ b/.azure/gpu-pipeline.yml
@@ -111,6 +111,8 @@ jobs:
       displayName: 'Show HF cache'
 
     - bash: python -m pytest torchmetrics --cov=torchmetrics --timeout=150 --durations=50
+      env:
+        SKIP_SLOW_DOCTEST: 1
       workingDirectory: src
       displayName: 'DocTesting'
 

--- a/.azure/gpu-pipeline.yml
+++ b/.azure/gpu-pipeline.yml
@@ -123,7 +123,8 @@ jobs:
       displayName: 'Pull testing data from S3'
 
     - bash: |
-        python -m pytest unittests -v --cov=torchmetrics --junitxml=$(Build.StagingDirectory)/test-results.xml --timeout=180 --durations=0
+        python -m pytest unittests -v --cov=torchmetrics --timeout=180 --durations=500 \
+          --junitxml=$(Build.StagingDirectory)/test-results.xml
       env:
         CUDA_LAUNCH_BLOCKING: 1
       workingDirectory: tests

--- a/.azure/gpu-pipeline.yml
+++ b/.azure/gpu-pipeline.yml
@@ -110,7 +110,7 @@ jobs:
         ls -lh $(HF_CACHE_DIR)  # show what was restored...
       displayName: 'Show HF cache'
 
-    - bash: python -m pytest torchmetrics --cov=torchmetrics --timeout=150 --durations=50
+    - bash: python -m pytest torchmetrics --timeout=180 --durations=50
       env:
         SKIP_SLOW_DOCTEST: 1
       workingDirectory: src

--- a/.github/workflows/ci-tests-full.yml
+++ b/.github/workflows/ci-tests-full.yml
@@ -51,7 +51,7 @@ jobs:
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     # seems that MacOS jobs take much more than orger OS
-    timeout-minutes: 105
+    timeout-minutes: 120
 
     steps:
     - uses: actions/checkout@v3
@@ -90,6 +90,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install pkg
+      timeout-minutes: 25
       run: |
         pip --version
         pip install -e . -U --find-links $PYTORCH_URL
@@ -98,9 +99,12 @@ jobs:
 
     # todo: copy this to install checks
     - name: DocTests
+      timeout-minutes: 25
       working-directory: ./src
+      env:
+        SKIP_SLOW_DOCTEST: 1
       # NOTE: run coverage on tests does not propagate failure status for Win, https://github.com/nedbat/coveragepy/issues/1003
-      run: python -m pytest torchmetrics --reruns 3 --reruns-delay 1
+      run: python -m pytest torchmetrics
 
     - name: Freeze PIL (hotfix)
       # import of PILLOW_VERSION which they recently removed in v9.0 in favor of __version__

--- a/.github/workflows/ci-tests-full.yml
+++ b/.github/workflows/ci-tests-full.yml
@@ -51,7 +51,7 @@ jobs:
 
     # Timeout: https://stackoverflow.com/a/59076067/4521646
     # seems that MacOS jobs take much more than orger OS
-    timeout-minutes: 95
+    timeout-minutes: 105
 
     steps:
     - uses: actions/checkout@v3

--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -11,13 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from typing import List, Tuple, Union
 
 import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
 
 if _TRANSFORMERS_AVAILABLE:
@@ -28,7 +29,7 @@ if _TRANSFORMERS_AVAILABLE:
         _CLIPModel.from_pretrained("openai/clip-vit-large-patch14")
         _CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14")
 
-    if _in_doctest() and not _try_proceed_with_timeout(_download_clip):
+    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_clip):
         __doctest_skip__ = ["clip_score"]
 
 else:

--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -17,11 +17,20 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
+from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
 
 if _TRANSFORMERS_AVAILABLE:
     from transformers import CLIPModel as _CLIPModel
     from transformers import CLIPProcessor as _CLIPProcessor
+
+    def _download_clip() -> None:
+        _CLIPModel.from_pretrained("openai/clip-vit-large-patch14")
+        _CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14")
+
+    if _in_doctest() and not _try_proceed_with_timeout(_download_clip):
+        __doctest_skip__ = ["clip_score"]
+
 else:
     __doctest_skip__ = ["clip_score"]
     _CLIPModel = None  # type:ignore

--- a/src/torchmetrics/functional/multimodal/clip_score.py
+++ b/src/torchmetrics/functional/multimodal/clip_score.py
@@ -18,7 +18,7 @@ import torch
 from torch import Tensor
 from typing_extensions import Literal
 
-from torchmetrics.utilities.checks import _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout, _SKIP_SLOW_DOCTEST
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
 
 if _TRANSFORMERS_AVAILABLE:
@@ -29,7 +29,7 @@ if _TRANSFORMERS_AVAILABLE:
         _CLIPModel.from_pretrained("openai/clip-vit-large-patch14")
         _CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14")
 
-    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_clip):
+    if _SKIP_SLOW_DOCTEST and not _try_proceed_with_timeout(_download_clip):
         __doctest_skip__ = ["clip_score"]
 
 else:

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -31,7 +31,7 @@ from torchmetrics.functional.text.helper_embedding_metric import (
     _output_data_collator,
     _process_attention_mask_for_special_tokens,
 )
-from torchmetrics.utilities.checks import _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout, _SKIP_SLOW_DOCTEST
 from torchmetrics.utilities.imports import _TQDM_AVAILABLE, _TRANSFORMERS_AVAILABLE
 
 # Default model recommended in the original implementation.
@@ -45,7 +45,7 @@ if _TRANSFORMERS_AVAILABLE:
         AutoTokenizer.from_pretrained(_DEFAULT_MODEL)
         AutoModel.from_pretrained(_DEFAULT_MODEL)
 
-    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_model):
+    if _SKIP_SLOW_DOCTEST and not _try_proceed_with_timeout(_download_model):
         __doctest_skip__ = ["bert_score"]
 else:
     __doctest_skip__ = ["bert_score"]

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import csv
+import os
 import urllib
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from warnings import warn
@@ -30,7 +31,7 @@ from torchmetrics.functional.text.helper_embedding_metric import (
     _output_data_collator,
     _process_attention_mask_for_special_tokens,
 )
-from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _TQDM_AVAILABLE, _TRANSFORMERS_AVAILABLE
 
 # Default model recommended in the original implementation.
@@ -44,7 +45,7 @@ if _TRANSFORMERS_AVAILABLE:
         AutoTokenizer.from_pretrained(_DEFAULT_MODEL)
         AutoModel.from_pretrained(_DEFAULT_MODEL)
 
-    if _in_doctest() and not _try_proceed_with_timeout(_download_model):
+    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_model):
         __doctest_skip__ = ["bert_score"]
 else:
     __doctest_skip__ = ["bert_score"]

--- a/src/torchmetrics/functional/text/bert.py
+++ b/src/torchmetrics/functional/text/bert.py
@@ -30,16 +30,24 @@ from torchmetrics.functional.text.helper_embedding_metric import (
     _output_data_collator,
     _process_attention_mask_for_special_tokens,
 )
+from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _TQDM_AVAILABLE, _TRANSFORMERS_AVAILABLE
-
-if _TRANSFORMERS_AVAILABLE:
-    from transformers import AutoModel, AutoTokenizer
-else:
-    __doctest_skip__ = ["bert_score"]
-
 
 # Default model recommended in the original implementation.
 _DEFAULT_MODEL = "roberta-large"
+
+if _TRANSFORMERS_AVAILABLE:
+    from transformers import AutoModel, AutoTokenizer
+
+    def _download_model() -> None:
+        """Download intensive operations."""
+        AutoTokenizer.from_pretrained(_DEFAULT_MODEL)
+        AutoModel.from_pretrained(_DEFAULT_MODEL)
+
+    if _in_doctest() and not _try_proceed_with_timeout(_download_model):
+        __doctest_skip__ = ["bert_score"]
+else:
+    __doctest_skip__ = ["bert_score"]
 
 
 def _get_embeddings_and_idf_scale(

--- a/src/torchmetrics/functional/text/rouge.py
+++ b/src/torchmetrics/functional/text/rouge.py
@@ -41,14 +41,6 @@ ALLOWED_ROUGE_KEYS: Dict[str, Union[int, str]] = {
 ALLOWED_ACCUMULATE_VALUES = ("avg", "best")
 
 
-def _is_internet_connection() -> bool:
-    try:
-        urllib.request.urlopen("https://torchmetrics.readthedocs.io/")
-    except HTTPError:
-        return False
-    return True
-
-
 def _ensure_nltk_punkt_is_downloaded() -> None:
     """Check whether `nltk` `punkt` is downloaded.
 
@@ -59,9 +51,9 @@ def _ensure_nltk_punkt_is_downloaded() -> None:
     try:
         nltk.data.find("tokenizers/punkt.zip")
     except LookupError:
-        if _is_internet_connection():
-            nltk.download("punkt", quiet=True, force=False)
-        else:
+        try:
+            nltk.download("punkt", quiet=True, force=False, halt_on_error=False, raise_on_error=True)
+        except ValueError:
             raise OSError(
                 "`nltk` resource `punkt` is not available on a disk and cannot be downloaded as a machine is not "
                 "connected to the internet."

--- a/src/torchmetrics/image/lpip.py
+++ b/src/torchmetrics/image/lpip.py
@@ -19,10 +19,17 @@ from torch.nn import Module
 from typing_extensions import Literal
 
 from torchmetrics.metric import Metric
+from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _LPIPS_AVAILABLE
 
 if _LPIPS_AVAILABLE:
     from lpips import LPIPS as _LPIPS
+
+    def _download_lpips() -> None:
+        _LPIPS(pretrained=True, net="vgg")
+
+    if _in_doctest() and not _try_proceed_with_timeout(_download_lpips):
+        __doctest_skip__ = ["LearnedPerceptualImagePatchSimilarity", "LPIPS"]
 else:
 
     class _LPIPS(Module):  # type: ignore

--- a/src/torchmetrics/image/lpip.py
+++ b/src/torchmetrics/image/lpip.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from typing import Any, List
 
 import torch
@@ -19,7 +20,7 @@ from torch.nn import Module
 from typing_extensions import Literal
 
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _LPIPS_AVAILABLE
 
 if _LPIPS_AVAILABLE:
@@ -28,7 +29,7 @@ if _LPIPS_AVAILABLE:
     def _download_lpips() -> None:
         _LPIPS(pretrained=True, net="vgg")
 
-    if _in_doctest() and not _try_proceed_with_timeout(_download_lpips):
+    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_lpips):
         __doctest_skip__ = ["LearnedPerceptualImagePatchSimilarity", "LPIPS"]
 else:
 

--- a/src/torchmetrics/image/lpip.py
+++ b/src/torchmetrics/image/lpip.py
@@ -20,7 +20,7 @@ from torch.nn import Module
 from typing_extensions import Literal
 
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.checks import _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout, _SKIP_SLOW_DOCTEST
 from torchmetrics.utilities.imports import _LPIPS_AVAILABLE
 
 if _LPIPS_AVAILABLE:
@@ -29,7 +29,7 @@ if _LPIPS_AVAILABLE:
     def _download_lpips() -> None:
         _LPIPS(pretrained=True, net="vgg")
 
-    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_lpips):
+    if _SKIP_SLOW_DOCTEST and not _try_proceed_with_timeout(_download_lpips):
         __doctest_skip__ = ["LearnedPerceptualImagePatchSimilarity", "LPIPS"]
 else:
 

--- a/src/torchmetrics/multimodal/clip_score.py
+++ b/src/torchmetrics/multimodal/clip_score.py
@@ -19,7 +19,7 @@ from torch import Tensor
 from typing_extensions import Literal
 
 from torchmetrics.functional.multimodal.clip_score import _clip_score_update, _get_model_and_processor
-from torchmetrics.utilities.checks import _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout, _SKIP_SLOW_DOCTEST
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
 
 if _TRANSFORMERS_AVAILABLE:
@@ -30,7 +30,7 @@ if _TRANSFORMERS_AVAILABLE:
         _CLIPModel.from_pretrained("openai/clip-vit-large-patch14")
         _CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14")
 
-    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_clip):
+    if _SKIP_SLOW_DOCTEST and not _try_proceed_with_timeout(_download_clip):
         __doctest_skip__ = ["CLIPScore"]
 else:
     __doctest_skip__ = ["CLIPScore"]

--- a/src/torchmetrics/multimodal/clip_score.py
+++ b/src/torchmetrics/multimodal/clip_score.py
@@ -18,9 +18,20 @@ from torch import Tensor
 from typing_extensions import Literal
 
 from torchmetrics.functional.multimodal.clip_score import _clip_score_update, _get_model_and_processor
+from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
 
-if not _TRANSFORMERS_AVAILABLE:
+if _TRANSFORMERS_AVAILABLE:
+    from transformers import CLIPModel as _CLIPModel
+    from transformers import CLIPProcessor as _CLIPProcessor
+
+    def _download_clip() -> None:
+        _CLIPModel.from_pretrained("openai/clip-vit-large-patch14")
+        _CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14")
+
+    if _in_doctest() and not _try_proceed_with_timeout(_download_clip):
+        __doctest_skip__ = ["CLIPScore"]
+else:
     __doctest_skip__ = ["CLIPScore"]
 
 from torchmetrics import Metric

--- a/src/torchmetrics/multimodal/clip_score.py
+++ b/src/torchmetrics/multimodal/clip_score.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from typing import Any, List, Union
 
 import torch
@@ -18,7 +19,7 @@ from torch import Tensor
 from typing_extensions import Literal
 
 from torchmetrics.functional.multimodal.clip_score import _clip_score_update, _get_model_and_processor
-from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
 
 if _TRANSFORMERS_AVAILABLE:
@@ -29,7 +30,7 @@ if _TRANSFORMERS_AVAILABLE:
         _CLIPModel.from_pretrained("openai/clip-vit-large-patch14")
         _CLIPProcessor.from_pretrained("openai/clip-vit-large-patch14")
 
-    if _in_doctest() and not _try_proceed_with_timeout(_download_clip):
+    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_clip):
         __doctest_skip__ = ["CLIPScore"]
 else:
     __doctest_skip__ = ["CLIPScore"]

--- a/src/torchmetrics/text/bert.py
+++ b/src/torchmetrics/text/bert.py
@@ -22,8 +22,11 @@ from torch.nn import Module
 from torchmetrics.functional.text.bert import bert_score
 from torchmetrics.functional.text.helper_embedding_metric import _preprocess_text
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.checks import _try_proceed_with_timeout, _SKIP_SLOW_DOCTEST
+from torchmetrics.utilities.checks import _SKIP_SLOW_DOCTEST, _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
+
+# Default model recommended in the original implementation.
+_DEFAULT_MODEL = "roberta-large"
 
 if _TRANSFORMERS_AVAILABLE:
     from transformers import AutoModel, AutoTokenizer
@@ -37,10 +40,6 @@ if _TRANSFORMERS_AVAILABLE:
         __doctest_skip__ = ["BERTScore"]
 else:
     __doctest_skip__ = ["BERTScore"]
-
-
-# Default model recommended in the original implementation.
-_DEFAULT_MODEL = "roberta-large"
 
 
 def _get_input_dict(input_ids: List[Tensor], attention_mask: List[Tensor]) -> Dict[str, Tensor]:

--- a/src/torchmetrics/text/bert.py
+++ b/src/torchmetrics/text/bert.py
@@ -22,7 +22,7 @@ from torch.nn import Module
 from torchmetrics.functional.text.bert import bert_score
 from torchmetrics.functional.text.helper_embedding_metric import _preprocess_text
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.checks import _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout, _SKIP_SLOW_DOCTEST
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
 
 if _TRANSFORMERS_AVAILABLE:
@@ -33,7 +33,7 @@ if _TRANSFORMERS_AVAILABLE:
         AutoTokenizer.from_pretrained(_DEFAULT_MODEL)
         AutoModel.from_pretrained(_DEFAULT_MODEL)
 
-    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_model):
+    if _SKIP_SLOW_DOCTEST and not _try_proceed_with_timeout(_download_model):
         __doctest_skip__ = ["BERTScore"]
 else:
     __doctest_skip__ = ["BERTScore"]

--- a/src/torchmetrics/text/bert.py
+++ b/src/torchmetrics/text/bert.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from typing import Any, Callable, Dict, List, Optional, Union
 from warnings import warn
 
@@ -21,7 +22,7 @@ from torch.nn import Module
 from torchmetrics.functional.text.bert import bert_score
 from torchmetrics.functional.text.helper_embedding_metric import _preprocess_text
 from torchmetrics.metric import Metric
-from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
+from torchmetrics.utilities.checks import _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
 
 if _TRANSFORMERS_AVAILABLE:
@@ -32,7 +33,7 @@ if _TRANSFORMERS_AVAILABLE:
         AutoTokenizer.from_pretrained(_DEFAULT_MODEL)
         AutoModel.from_pretrained(_DEFAULT_MODEL)
 
-    if _in_doctest() and not _try_proceed_with_timeout(_download_model):
+    if bool(os.environ.get("SKIP_SLOW_DOCTEST", 0)) and not _try_proceed_with_timeout(_download_model):
         __doctest_skip__ = ["BERTScore"]
 else:
     __doctest_skip__ = ["BERTScore"]

--- a/src/torchmetrics/text/bert.py
+++ b/src/torchmetrics/text/bert.py
@@ -21,10 +21,19 @@ from torch.nn import Module
 from torchmetrics.functional.text.bert import bert_score
 from torchmetrics.functional.text.helper_embedding_metric import _preprocess_text
 from torchmetrics.metric import Metric
+from torchmetrics.utilities.checks import _in_doctest, _try_proceed_with_timeout
 from torchmetrics.utilities.imports import _TRANSFORMERS_AVAILABLE
 
 if _TRANSFORMERS_AVAILABLE:
-    from transformers import AutoTokenizer
+    from transformers import AutoModel, AutoTokenizer
+
+    def _download_model() -> None:
+        """Download intensive operations."""
+        AutoTokenizer.from_pretrained(_DEFAULT_MODEL)
+        AutoModel.from_pretrained(_DEFAULT_MODEL)
+
+    if _in_doctest() and not _try_proceed_with_timeout(_download_model):
+        __doctest_skip__ = ["BERTScore"]
 else:
     __doctest_skip__ = ["BERTScore"]
 

--- a/src/torchmetrics/utilities/checks.py
+++ b/src/torchmetrics/utilities/checks.py
@@ -758,14 +758,8 @@ def is_overridden(method_name: str, instance: object, parent: object) -> bool:
 
 
 def _in_doctest() -> bool:
-    """Determine if script running in doctest context."""
-    if "_pytest.doctest" in sys.modules:
-        return True
-    if hasattr(sys.modules["__main__"], "_SpoofOut"):
-        return True
-    if sys.modules["__main__"].__dict__.get("__file__", "").endswith("/pytest"):
-        return True
-    return False
+    """For skipping slow doctest."""
+    return bool(os.environ.get("SKIP_SLOW_DOCTEST", 0))
 
 
 def _try_proceed_with_timeout(fn: Callable, timeout: int = _DOCTEST_DOWNLOAD_TIMEOUT) -> bool:

--- a/src/torchmetrics/utilities/checks.py
+++ b/src/torchmetrics/utilities/checks.py
@@ -14,7 +14,6 @@
 import logging
 import multiprocessing
 import os
-import sys
 from functools import partial
 from time import perf_counter
 from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, no_type_check
@@ -27,6 +26,7 @@ from torchmetrics.utilities.data import select_topk, to_onehot
 from torchmetrics.utilities.enums import DataType
 
 _DOCTEST_DOWNLOAD_TIMEOUT = os.environ.get("DOCTEST_DOWNLOAD_TIMEOUT", 120)
+_SKIP_SLOW_DOCTEST = bool(os.environ.get("SKIP_SLOW_DOCTEST", 0))
 
 
 def _check_for_empty_tensors(preds: Tensor, target: Tensor) -> bool:

--- a/src/torchmetrics/utilities/checks.py
+++ b/src/torchmetrics/utilities/checks.py
@@ -757,11 +757,6 @@ def is_overridden(method_name: str, instance: object, parent: object) -> bool:
     return instance_attr.__code__ != parent_attr.__code__
 
 
-def _in_doctest() -> bool:
-    """For skipping slow doctest."""
-    return bool(os.environ.get("SKIP_SLOW_DOCTEST", 0))
-
-
 def _try_proceed_with_timeout(fn: Callable, timeout: int = _DOCTEST_DOWNLOAD_TIMEOUT) -> bool:
     """Function for checking if a certain function is taking too long to execute.
 

--- a/src/torchmetrics/utilities/checks.py
+++ b/src/torchmetrics/utilities/checks.py
@@ -11,9 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+import multiprocessing
+import os
+import sys
 from functools import partial
 from time import perf_counter
-from typing import Any, Dict, Mapping, Optional, Sequence, Tuple, no_type_check
+from typing import Any, Callable, Dict, Mapping, Optional, Sequence, Tuple, no_type_check
 from unittest.mock import Mock
 
 import torch
@@ -21,6 +25,8 @@ from torch import Tensor
 
 from torchmetrics.utilities.data import select_topk, to_onehot
 from torchmetrics.utilities.enums import DataType
+
+_DOCTEST_DOWNLOAD_TIMEOUT = os.environ.get("DOCTEST_DOWNLOAD_TIMEOUT", 120)
 
 
 def _check_for_empty_tensors(preds: Tensor, target: Tensor) -> bool:
@@ -749,3 +755,44 @@ def is_overridden(method_name: str, instance: object, parent: object) -> bool:
         raise ValueError("The parent should define the method")
 
     return instance_attr.__code__ != parent_attr.__code__
+
+
+def _in_doctest() -> bool:
+    """Determine if script running in doctest context."""
+    if "_pytest.doctest" in sys.modules:
+        return True
+    if hasattr(sys.modules["__main__"], "_SpoofOut"):
+        return True
+    if sys.modules["__main__"].__dict__.get("__file__", "").endswith("/pytest"):
+        return True
+    return False
+
+
+def _try_proceed_with_timeout(fn: Callable, timeout: int = _DOCTEST_DOWNLOAD_TIMEOUT) -> bool:
+    """Function for checking if a certain function is taking too long to execute.
+
+    Function will only be executed if running inside a doctest context. Currently does not support Windows.
+
+    Args:
+        fn: function to check
+        timeout: timeout for function
+
+    Returns:
+        Bool indicating if the function finished within the specified timeout
+    """
+    # source: https://stackoverflow.com/a/14924210/4521646
+    proc = multiprocessing.Process(target=fn)
+    proc.start()
+    # Wait for 10 seconds or until process finishes
+    proc.join(timeout)
+    # If thread is still active
+    if not proc.is_alive():
+        return True
+
+    logging.warning(f"running `{fn.__name__}`... let's kill it...")
+    # Terminate - may not work if process is stuck for good
+    proc.terminate()
+    # OR Kill - will work for sure, no chance for process to finish nicely however
+    # p.kill()
+    proc.join()
+    return False

--- a/tests/unittests/text/helpers.py
+++ b/tests/unittests/text/helpers.py
@@ -440,11 +440,11 @@ class TextTester(MetricTester):
 
 
 def skip_on_connection_issues(reason: str = "Unable to load checkpoints from HuggingFace `transformers`."):
-    """Wrapper which handles HF-related tests if they fail due to connection issues.
+    """Wrapper which handles download related tests if they fail due to connection issues.
 
     The tests run normally if no connection issue arises, and they're marked as skipped otherwise.
     """
-    _error_msg_starts = ["We couldn't connect to", "Connection error", "Can't load"]
+    _error_msg_starts = ["We couldn't connect to", "Connection error", "Can't load", "`nltk` resource `punkt` is"]
 
     def test_decorator(function: Callable, *args: Any, **kwargs: Any) -> Optional[Callable]:
         @wraps(function)

--- a/tests/unittests/text/test_rouge.py
+++ b/tests/unittests/text/test_rouge.py
@@ -24,7 +24,7 @@ from typing_extensions import Literal
 from torchmetrics.functional.text.rouge import rouge_score
 from torchmetrics.text.rouge import ROUGEScore
 from torchmetrics.utilities.imports import _NLTK_AVAILABLE, _ROUGE_SCORE_AVAILABLE
-from unittests.text.helpers import TextTester
+from unittests.text.helpers import TextTester, skip_on_connection_issues
 from unittests.text.inputs import Input, _inputs_multiple_references, _inputs_single_sentence_single_reference
 
 if _ROUGE_SCORE_AVAILABLE:
@@ -118,6 +118,7 @@ def _compute_rouge_score(
 class TestROUGEScore(TextTester):
     @pytest.mark.parametrize("ddp", [False, True])
     @pytest.mark.parametrize("dist_sync_on_step", [False, True])
+    @skip_on_connection_issues(reason="could not download nltl relevant data")
     def test_rouge_score_class(
         self, ddp, dist_sync_on_step, preds, targets, pl_rouge_metric_key, use_stemmer, accumulate
     ):
@@ -137,6 +138,7 @@ class TestROUGEScore(TextTester):
             key=pl_rouge_metric_key,
         )
 
+    @skip_on_connection_issues(reason="could not download nltl relevant data")
     def test_rouge_score_functional(self, preds, targets, pl_rouge_metric_key, use_stemmer, accumulate):
         metric_args = {"use_stemmer": use_stemmer, "accumulate": accumulate}
 
@@ -197,6 +199,7 @@ def test_rouge_metric_wrong_key_value_error():
         "rougeLsum_fmeasure",
     ],
 )
+@skip_on_connection_issues(reason="could not download nltl relevant data")
 def test_rouge_metric_normalizer_tokenizer(pl_rouge_metric_key):
     normalizer: Callable[[str], str] = lambda text: re.sub(r"[^a-z0-9]+", " ", text.lower())
     tokenizer: Callable[[str], Sequence[str]] = lambda text: re.split(r"\s+", text)
@@ -235,6 +238,7 @@ def test_rouge_metric_normalizer_tokenizer(pl_rouge_metric_key):
     ],
 )
 @pytest.mark.parametrize("use_stemmer", [False, True])
+@skip_on_connection_issues(reason="could not download nltl relevant data")
 def test_rouge_lsum_score(pl_rouge_metric_key, use_stemmer):
     """Specific tests to verify the correctness of Rouge-L and Rouge-LSum metric."""
     rouge_level, metric = pl_rouge_metric_key.split("_")

--- a/tests/unittests/text/test_rouge.py
+++ b/tests/unittests/text/test_rouge.py
@@ -118,7 +118,7 @@ def _compute_rouge_score(
 class TestROUGEScore(TextTester):
     @pytest.mark.parametrize("ddp", [False, True])
     @pytest.mark.parametrize("dist_sync_on_step", [False, True])
-    @skip_on_connection_issues(reason="could not download nltl relevant data")
+    @skip_on_connection_issues(reason="could not download nltk relevant data")
     def test_rouge_score_class(
         self, ddp, dist_sync_on_step, preds, targets, pl_rouge_metric_key, use_stemmer, accumulate
     ):
@@ -138,7 +138,7 @@ class TestROUGEScore(TextTester):
             key=pl_rouge_metric_key,
         )
 
-    @skip_on_connection_issues(reason="could not download nltl relevant data")
+    @skip_on_connection_issues(reason="could not download nltk relevant data")
     def test_rouge_score_functional(self, preds, targets, pl_rouge_metric_key, use_stemmer, accumulate):
         metric_args = {"use_stemmer": use_stemmer, "accumulate": accumulate}
 
@@ -199,7 +199,7 @@ def test_rouge_metric_wrong_key_value_error():
         "rougeLsum_fmeasure",
     ],
 )
-@skip_on_connection_issues(reason="could not download nltl relevant data")
+@skip_on_connection_issues(reason="could not download nltk relevant data")
 def test_rouge_metric_normalizer_tokenizer(pl_rouge_metric_key):
     normalizer: Callable[[str], str] = lambda text: re.sub(r"[^a-z0-9]+", " ", text.lower())
     tokenizer: Callable[[str], Sequence[str]] = lambda text: re.split(r"\s+", text)
@@ -238,7 +238,7 @@ def test_rouge_metric_normalizer_tokenizer(pl_rouge_metric_key):
     ],
 )
 @pytest.mark.parametrize("use_stemmer", [False, True])
-@skip_on_connection_issues(reason="could not download nltl relevant data")
+@skip_on_connection_issues(reason="could not download nltk relevant data")
 def test_rouge_lsum_score(pl_rouge_metric_key, use_stemmer):
     """Specific tests to verify the correctness of Rouge-L and Rouge-LSum metric."""
     rouge_level, metric = pl_rouge_metric_key.split("_")


### PR DESCRIPTION
## What does this PR do?

Changes the logic introduced in https://github.com/Lightning-AI/metrics/pull/1505 to an env variable instead.
Additionally, add skipping to rouge metric if download is not available as it sometimes silently halts (and there timeout the tests).

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
