### PR TITLE
docs: typo in FID documentation

### DIFF
--- a/src/torchmetrics/image/inception.py
+++ b/src/torchmetrics/image/inception.py
@@ -27,7 +27,7 @@ __doctest_requires__ = {("InceptionScore", "IS"): ["torch_fidelity"]}
 
 
 class InceptionScore(Metric):
-    r"""Calculate the Inception Score (IS) which is used to access how realistic generated images are. It is
+    r"""Calculate the Inception Score (IS) which is used to assess how realistic generated images are. It is
     defined as.
 
     .. math::


### PR DESCRIPTION
## "Access" was used where "assess" should have been used.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [x] Did you make sure to **update the docs**?
- [x] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Yup! Because looking through the docs meant that I didn't have to implement FID. Very fun indeed!
