### PR TITLE
Faster CI using shared pool

### DIFF
--- a/tests/unittests/__init__.py
+++ b/tests/unittests/__init__.py
@@ -2,7 +2,7 @@ import os.path
 
 import torch
 
-from unittests.conftest import BATCH_SIZE, NUM_BATCHES, NUM_PROCESSES  # noqa: F401
+from unittests.conftest import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, NUM_CLASSES, NUM_PROCESSES, setup_ddp  # noqa: F401
 
 _PATH_TESTS = os.path.dirname(__file__)
 _PATH_ROOT = os.path.dirname(_PATH_TESTS)

--- a/tests/unittests/__init__.py
+++ b/tests/unittests/__init__.py
@@ -2,7 +2,7 @@ import os.path
 
 import torch
 
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, NUM_PROCESSES, DummyMetric, MetricTester  # noqa: F401
+from unittests.conftest import BATCH_SIZE, NUM_BATCHES, NUM_PROCESSES  # noqa: F401
 
 _PATH_TESTS = os.path.dirname(__file__)
 _PATH_ROOT = os.path.dirname(_PATH_TESTS)

--- a/tests/unittests/__init__.py
+++ b/tests/unittests/__init__.py
@@ -2,7 +2,15 @@ import os.path
 
 import torch
 
-from unittests.conftest import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, NUM_CLASSES, NUM_PROCESSES, setup_ddp  # noqa: F401
+from unittests.conftest import (  # noqa: F401
+    BATCH_SIZE,
+    EXTRA_DIM,
+    NUM_BATCHES,
+    NUM_CLASSES,
+    NUM_PROCESSES,
+    THRESHOLD,
+    setup_ddp,
+)
 
 _PATH_TESTS = os.path.dirname(__file__)
 _PATH_ROOT = os.path.dirname(_PATH_TESTS)

--- a/tests/unittests/audio/test_pit.py
+++ b/tests/unittests/audio/test_pit.py
@@ -27,8 +27,9 @@ from torchmetrics.functional import (
     scale_invariant_signal_distortion_ratio,
     signal_noise_ratio,
 )
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/audio/test_si_sdr.py
+++ b/tests/unittests/audio/test_si_sdr.py
@@ -21,8 +21,9 @@ from torch import Tensor
 
 from torchmetrics.audio import ScaleInvariantSignalDistortionRatio
 from torchmetrics.functional import scale_invariant_signal_distortion_ratio
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/audio/test_si_snr.py
+++ b/tests/unittests/audio/test_si_snr.py
@@ -21,8 +21,9 @@ from torch import Tensor
 
 from torchmetrics.audio import ScaleInvariantSignalNoiseRatio
 from torchmetrics.functional import scale_invariant_signal_noise_ratio
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/audio/test_snr.py
+++ b/tests/unittests/audio/test_snr.py
@@ -22,8 +22,9 @@ from torch import Tensor
 
 from torchmetrics.audio import SignalNoiseRatio
 from torchmetrics.functional import signal_noise_ratio
+from unittests import NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/bases/test_aggregation.py
+++ b/tests/unittests/bases/test_aggregation.py
@@ -3,7 +3,8 @@ import pytest
 import torch
 
 from torchmetrics.aggregation import CatMetric, MaxMetric, MeanMetric, MinMetric, SumMetric
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests import BATCH_SIZE, NUM_BATCHES
+from unittests.helpers.testers import MetricTester
 
 
 def compare_mean(values, weights):

--- a/tests/unittests/bases/test_ddp.py
+++ b/tests/unittests/bases/test_ddp.py
@@ -14,6 +14,7 @@
 import os
 import sys
 from copy import deepcopy
+from functools import partial
 
 import pytest
 import torch
@@ -22,24 +23,23 @@ from torch import tensor
 from torchmetrics import Metric
 from torchmetrics.utilities.distributed import gather_all_tensors
 from torchmetrics.utilities.exceptions import TorchMetricsUserError
+from unittests import NUM_PROCESSES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import DummyListMetric, DummyMetric, DummyMetricSum, setup_ddp
+from unittests.helpers.testers import DummyListMetric, DummyMetric, DummyMetricSum
 
 seed_all(42)
 
 
-def _test_ddp_sum(rank, worldsize):
-    setup_ddp(rank, worldsize)
+def _test_ddp_sum(rank):
     dummy = DummyMetric()
     dummy._reductions = {"foo": torch.sum}
     dummy.foo = tensor(1)
     dummy._sync_dist()
 
-    assert dummy.foo == worldsize
+    assert dummy.foo == NUM_PROCESSES
 
 
-def _test_ddp_cat(rank, worldsize):
-    setup_ddp(rank, worldsize)
+def _test_ddp_cat(rank):
     dummy = DummyMetric()
     dummy._reductions = {"foo": torch.cat}
     dummy.foo = [tensor([1])]
@@ -48,8 +48,7 @@ def _test_ddp_cat(rank, worldsize):
     assert torch.all(torch.eq(dummy.foo, tensor([1, 1])))
 
 
-def _test_ddp_sum_cat(rank, worldsize):
-    setup_ddp(rank, worldsize)
+def _test_ddp_sum_cat(rank):
     dummy = DummyMetric()
     dummy._reductions = {"foo": torch.cat, "bar": torch.sum}
     dummy.foo = [tensor([1])]
@@ -57,38 +56,33 @@ def _test_ddp_sum_cat(rank, worldsize):
     dummy._sync_dist()
 
     assert torch.all(torch.eq(dummy.foo, tensor([1, 1])))
-    assert dummy.bar == worldsize
+    assert dummy.bar == NUM_PROCESSES
 
 
-def _test_ddp_gather_uneven_tensors(rank, worldsize):
-    setup_ddp(rank, worldsize)
+def _test_ddp_gather_uneven_tensors(rank):
     tensor = torch.ones(rank)
     result = gather_all_tensors(tensor)
-    assert len(result) == worldsize
-    for idx in range(worldsize):
-        assert len(result[idx]) == idx
+    assert len(result) == NUM_PROCESSES
+    for idx in range(NUM_PROCESSES):
         assert (result[idx] == torch.ones_like(result[idx])).all()
 
 
-def _test_ddp_gather_uneven_tensors_multidim(rank, worldsize):
-    setup_ddp(rank, worldsize)
+def _test_ddp_gather_uneven_tensors_multidim(rank):
     tensor = torch.ones(rank + 1, 2 - rank)
     result = gather_all_tensors(tensor)
-    assert len(result) == worldsize
-    for idx in range(worldsize):
+    assert len(result) == NUM_PROCESSES
+    for idx in range(NUM_PROCESSES):
         val = result[idx]
-        assert val.shape == (idx + 1, 2 - idx)
         assert (val == torch.ones_like(val)).all()
 
 
-def _test_ddp_compositional_tensor(rank, worldsize):
-    setup_ddp(rank, worldsize)
+def _test_ddp_compositional_tensor(rank):
     dummy = DummyMetricSum()
     dummy._reductions = {"x": torch.sum}
     dummy = dummy.clone() + dummy.clone()
     dummy.update(tensor(1))
     val = dummy.compute()
-    assert val == 2 * worldsize
+    assert val == 2 * NUM_PROCESSES
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="DDP not available on windows")
@@ -104,12 +98,10 @@ def _test_ddp_compositional_tensor(rank, worldsize):
     ],
 )
 def test_ddp(process):
-    torch.multiprocessing.spawn(process, args=(2,), nprocs=2)
+    pytest.pool.map(process, range(NUM_PROCESSES))
 
 
-def _test_non_contiguous_tensors(rank, worldsize):
-    setup_ddp(rank, worldsize)
-
+def _test_non_contiguous_tensors(rank):
     class DummyCatMetric(Metric):
         full_state_update = True
 
@@ -131,12 +123,10 @@ def _test_non_contiguous_tensors(rank, worldsize):
 @pytest.mark.skipif(sys.platform == "win32", reason="DDP not available on windows")
 def test_non_contiguous_tensors():
     """Test that gather_all operation works for non contiguous tensors."""
-    torch.multiprocessing.spawn(_test_non_contiguous_tensors, args=(2,), nprocs=2)
+    pytest.pool.map(_test_non_contiguous_tensors, range(NUM_PROCESSES))
 
 
-def _test_state_dict_is_synced(rank, worldsize, tmpdir):
-    setup_ddp(rank, worldsize)
-
+def _test_state_dict_is_synced(rank, tmpdir):
     class DummyCatMetric(Metric):
         full_state_update = True
 
@@ -241,11 +231,10 @@ def _test_state_dict_is_synced(rank, worldsize, tmpdir):
 @pytest.mark.skipif(sys.platform == "win32", reason="DDP not available on windows")
 def test_state_dict_is_synced(tmpdir):
     """Tests that metrics are synced while creating the state dict but restored after to continue accumulation."""
-    torch.multiprocessing.spawn(_test_state_dict_is_synced, args=(2, tmpdir), nprocs=2)
+    pytest.pool.map(partial(_test_state_dict_is_synced, tmpdir=tmpdir), range(NUM_PROCESSES))
 
 
-def _test_sync_on_compute_tensor_state(rank, worldsize, sync_on_compute):
-    setup_ddp(rank, worldsize)
+def _test_sync_on_compute_tensor_state(rank, sync_on_compute):
     dummy = DummyMetricSum(sync_on_compute=sync_on_compute)
     dummy.update(tensor(rank + 1))
     val = dummy.compute()
@@ -255,13 +244,13 @@ def _test_sync_on_compute_tensor_state(rank, worldsize, sync_on_compute):
         assert val == rank + 1
 
 
-def _test_sync_on_compute_list_state(rank, worldsize, sync_on_compute):
-    setup_ddp(rank, worldsize)
+def _test_sync_on_compute_list_state(rank, sync_on_compute):
     dummy = DummyListMetric(sync_on_compute=sync_on_compute)
     dummy.update(tensor(rank + 1))
     val = dummy.compute()
     if sync_on_compute:
-        assert torch.allclose(val, tensor([1, 2]))
+        assert val.sum() == 3
+        assert torch.allclose(val, tensor([1, 2])) or torch.allclose(val, tensor([2, 1]))
     else:
         assert val == [tensor(rank + 1)]
 
@@ -271,11 +260,10 @@ def _test_sync_on_compute_list_state(rank, worldsize, sync_on_compute):
 @pytest.mark.parametrize("test_func", [_test_sync_on_compute_list_state, _test_sync_on_compute_tensor_state])
 def test_sync_on_compute(sync_on_compute, test_func):
     """Test that syncronization of states can be enabled and disabled for compute."""
-    torch.multiprocessing.spawn(test_func, args=(2, sync_on_compute), nprocs=2)
+    pytest.pool.map(partial(test_func, sync_on_compute=sync_on_compute), range(NUM_PROCESSES))
 
 
-def _test_sync_with_empty_lists(rank, worldsize):
-    setup_ddp(rank, worldsize)
+def _test_sync_with_empty_lists(rank):
     dummy = DummyListMetric()
     val = dummy.compute()
     assert val == []
@@ -284,4 +272,4 @@ def _test_sync_with_empty_lists(rank, worldsize):
 @pytest.mark.skipif(sys.platform == "win32", reason="DDP not available on windows")
 def test_sync_with_empty_lists():
     """Test that syncronization of states can be enabled and disabled for compute."""
-    torch.multiprocessing.spawn(_test_sync_with_empty_lists, args=(2,), nprocs=2)
+    pytest.pool.map(_test_sync_with_empty_lists, range(NUM_PROCESSES))

--- a/tests/unittests/classification/inputs.py
+++ b/tests/unittests/classification/inputs.py
@@ -17,8 +17,8 @@ import pytest
 import torch
 from torch import Tensor
 
+from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, NUM_CLASSES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, NUM_CLASSES
 
 seed_all(1)
 

--- a/tests/unittests/classification/test_accuracy.py
+++ b/tests/unittests/classification/test_accuracy.py
@@ -22,9 +22,10 @@ from sklearn.metrics import confusion_matrix as sk_confusion_matrix
 
 from torchmetrics.classification.accuracy import BinaryAccuracy, MulticlassAccuracy, MultilabelAccuracy
 from torchmetrics.functional.classification.accuracy import binary_accuracy, multiclass_accuracy, multilabel_accuracy
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_auroc.py
+++ b/tests/unittests/classification/test_auroc.py
@@ -23,9 +23,10 @@ from sklearn.metrics import roc_auc_score as sk_roc_auc_score
 from torchmetrics.classification.auroc import BinaryAUROC, MulticlassAUROC, MultilabelAUROC
 from torchmetrics.functional.classification.auroc import binary_auroc, multiclass_auroc, multilabel_auroc
 from torchmetrics.functional.classification.roc import binary_roc
+from unittests import NUM_CLASSES
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_average_precision.py
+++ b/tests/unittests/classification/test_average_precision.py
@@ -31,9 +31,10 @@ from torchmetrics.functional.classification.average_precision import (
     multilabel_average_precision,
 )
 from torchmetrics.functional.classification.precision_recall_curve import binary_precision_recall_curve
+from unittests import NUM_CLASSES
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_calibration_error.py
+++ b/tests/unittests/classification/test_calibration_error.py
@@ -26,9 +26,10 @@ from torchmetrics.functional.classification.calibration_error import (
     multiclass_calibration_error,
 )
 from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_9
+from unittests import NUM_CLASSES
 from unittests.classification.inputs import _binary_cases, _multiclass_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_cohen_kappa.py
+++ b/tests/unittests/classification/test_cohen_kappa.py
@@ -21,9 +21,10 @@ from sklearn.metrics import cohen_kappa_score as sk_cohen_kappa
 
 from torchmetrics.classification.cohen_kappa import BinaryCohenKappa, MulticlassCohenKappa
 from torchmetrics.functional.classification.cohen_kappa import binary_cohen_kappa, multiclass_cohen_kappa
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_confusion_matrix.py
+++ b/tests/unittests/classification/test_confusion_matrix.py
@@ -29,9 +29,10 @@ from torchmetrics.functional.classification.confusion_matrix import (
     multiclass_confusion_matrix,
     multilabel_confusion_matrix,
 )
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_exact_match.py
+++ b/tests/unittests/classification/test_exact_match.py
@@ -20,9 +20,10 @@ from scipy.special import expit as sigmoid
 
 from torchmetrics.classification.exact_match import MulticlassExactMatch, MultilabelExactMatch
 from torchmetrics.functional.classification.exact_match import multiclass_exact_match, multilabel_exact_match
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_f_beta.py
+++ b/tests/unittests/classification/test_f_beta.py
@@ -38,9 +38,10 @@ from torchmetrics.functional.classification.f_beta import (
     multilabel_f1_score,
     multilabel_fbeta_score,
 )
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_hamming_distance.py
+++ b/tests/unittests/classification/test_hamming_distance.py
@@ -30,9 +30,10 @@ from torchmetrics.functional.classification.hamming import (
     multiclass_hamming_distance,
     multilabel_hamming_distance,
 )
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_hinge.py
+++ b/tests/unittests/classification/test_hinge.py
@@ -23,8 +23,9 @@ from sklearn.preprocessing import OneHotEncoder
 
 from torchmetrics.classification.hinge import BinaryHingeLoss, MulticlassHingeLoss
 from torchmetrics.functional.classification.hinge import binary_hinge_loss, multiclass_hinge_loss
+from unittests import NUM_CLASSES
 from unittests.classification.inputs import _binary_cases, _multiclass_cases
-from unittests.helpers.testers import NUM_CLASSES, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 torch.manual_seed(42)
 

--- a/tests/unittests/classification/test_jaccard.py
+++ b/tests/unittests/classification/test_jaccard.py
@@ -26,8 +26,9 @@ from torchmetrics.functional.classification.jaccard import (
     multiclass_jaccard_index,
     multilabel_jaccard_index,
 )
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 
 def _sklearn_jaccard_index_binary(preds, target, ignore_index=None):

--- a/tests/unittests/classification/test_matthews_corrcoef.py
+++ b/tests/unittests/classification/test_matthews_corrcoef.py
@@ -29,9 +29,10 @@ from torchmetrics.functional.classification.matthews_corrcoef import (
     multiclass_matthews_corrcoef,
     multilabel_matthews_corrcoef,
 )
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_precision_recall.py
+++ b/tests/unittests/classification/test_precision_recall.py
@@ -38,9 +38,10 @@ from torchmetrics.functional.classification.precision_recall import (
     multilabel_precision,
     multilabel_recall,
 )
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_precision_recall_curve.py
+++ b/tests/unittests/classification/test_precision_recall_curve.py
@@ -30,9 +30,10 @@ from torchmetrics.functional.classification.precision_recall_curve import (
     multiclass_precision_recall_curve,
     multilabel_precision_recall_curve,
 )
+from unittests import NUM_CLASSES
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_ranking.py
+++ b/tests/unittests/classification/test_ranking.py
@@ -32,9 +32,10 @@ from torchmetrics.functional.classification.ranking import (
     multilabel_ranking_loss,
 )
 from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_9
+from unittests import NUM_CLASSES
 from unittests.classification.inputs import _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, MetricTester, inject_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_recall_at_fixed_precision.py
+++ b/tests/unittests/classification/test_recall_at_fixed_precision.py
@@ -31,9 +31,10 @@ from torchmetrics.functional.classification.recall_at_fixed_precision import (
     multiclass_recall_at_fixed_precision,
     multilabel_recall_at_fixed_precision,
 )
+from unittests import NUM_CLASSES
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_roc.py
+++ b/tests/unittests/classification/test_roc.py
@@ -22,9 +22,10 @@ from sklearn.metrics import roc_curve as sk_roc_curve
 
 from torchmetrics.classification.roc import BinaryROC, MulticlassROC, MultilabelROC
 from torchmetrics.functional.classification.roc import binary_roc, multiclass_roc, multilabel_roc
+from unittests import NUM_CLASSES
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_specificity.py
+++ b/tests/unittests/classification/test_specificity.py
@@ -26,9 +26,10 @@ from torchmetrics.functional.classification.specificity import (
     multiclass_specificity,
     multilabel_specificity,
 )
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_specificity_at_sensitivity.py
+++ b/tests/unittests/classification/test_specificity_at_sensitivity.py
@@ -32,9 +32,10 @@ from torchmetrics.functional.classification.specificity_at_sensitivity import (
     multiclass_specificity_at_sensitivity,
     multilabel_specificity_at_sensitivity,
 )
+from unittests import NUM_CLASSES
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/classification/test_stat_scores.py
+++ b/tests/unittests/classification/test_stat_scores.py
@@ -25,9 +25,10 @@ from torchmetrics.functional.classification.stat_scores import (
     multiclass_stat_scores,
     multilabel_stat_scores,
 )
+from unittests import NUM_CLASSES, THRESHOLD
 from unittests.classification.inputs import _binary_cases, _multiclass_cases, _multilabel_cases
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_CLASSES, THRESHOLD, MetricTester, inject_ignore_index, remove_ignore_index
+from unittests.helpers.testers import MetricTester, inject_ignore_index, remove_ignore_index
 
 seed_all(42)
 

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -22,7 +22,7 @@ from torch.multiprocessing import Pool, set_start_method
 with contextlib.suppress(RuntimeError):
     set_start_method("spawn")
 
-NUM_PROCESSES = torch.cuda.device_count() if torch.cuda.is_available() else 2
+NUM_PROCESSES = 2  # torch.cuda.device_count() if torch.cuda.is_available() else 2
 NUM_BATCHES = 2 * NUM_PROCESSES  # Need to be divisible with the number of processes
 BATCH_SIZE = 32
 NUM_CLASSES = 5

--- a/tests/unittests/conftest.py
+++ b/tests/unittests/conftest.py
@@ -1,0 +1,60 @@
+# Copyright The Lightning team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import contextlib
+import os
+import sys
+
+import pytest
+import torch
+from torch.multiprocessing import Pool, set_start_method
+
+with contextlib.suppress(RuntimeError):
+    set_start_method("spawn")
+
+NUM_PROCESSES = torch.cuda.device_count() if torch.cuda.is_available() else 2
+NUM_BATCHES = 2 * NUM_PROCESSES  # Need to be divisible with the number of processes
+BATCH_SIZE = 32
+NUM_CLASSES = 5
+EXTRA_DIM = 3
+THRESHOLD = 0.5
+
+MAX_PORT = 8100
+START_PORT = 8088
+CURRENT_PORT = START_PORT
+
+
+def setup_ddp(rank, world_size):
+    """Setup ddp environment."""
+    global CURRENT_PORT
+
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(CURRENT_PORT)
+
+    CURRENT_PORT += 1
+    if CURRENT_PORT > MAX_PORT:
+        CURRENT_PORT = START_PORT
+
+    if torch.distributed.is_available() and sys.platform not in ("win32", "cygwin"):
+        torch.distributed.init_process_group("gloo", rank=rank, world_size=world_size)
+
+
+def pytest_sessionstart():
+    pool = Pool(processes=NUM_PROCESSES)
+    pool.starmap(setup_ddp, [(rank, NUM_PROCESSES) for rank in range(NUM_PROCESSES)])
+    pytest.pool = pool
+
+
+def pytest_sessionfinish():
+    pytest.pool.close()
+    pytest.pool.join()

--- a/tests/unittests/image/test_d_lambda.py
+++ b/tests/unittests/image/test_d_lambda.py
@@ -21,8 +21,9 @@ import torch
 from torchmetrics.functional.image.d_lambda import spectral_distortion_index
 from torchmetrics.functional.image.uqi import universal_image_quality_index
 from torchmetrics.image.d_lambda import SpectralDistortionIndex
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/image/test_ergas.py
+++ b/tests/unittests/image/test_ergas.py
@@ -21,8 +21,9 @@ from torch import Tensor
 
 from torchmetrics.functional.image.ergas import error_relative_global_dimensionless_synthesis
 from torchmetrics.image.ergas import ErrorRelativeGlobalDimensionlessSynthesis
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/image/test_ms_ssim.py
+++ b/tests/unittests/image/test_ms_ssim.py
@@ -20,8 +20,9 @@ from pytorch_msssim import ms_ssim
 
 from torchmetrics.functional.image.ssim import multiscale_structural_similarity_index_measure
 from torchmetrics.image.ssim import MultiScaleStructuralSimilarityIndexMeasure
+from unittests import NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/image/test_psnr.py
+++ b/tests/unittests/image/test_psnr.py
@@ -22,8 +22,9 @@ from skimage.metrics import peak_signal_noise_ratio as skimage_peak_signal_noise
 
 from torchmetrics.functional import peak_signal_noise_ratio
 from torchmetrics.image import PeakSignalNoiseRatio
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/image/test_sam.py
+++ b/tests/unittests/image/test_sam.py
@@ -21,8 +21,9 @@ from torch.nn import functional as F  # noqa: N812
 
 from torchmetrics.functional.image.sam import spectral_angle_mapper
 from torchmetrics.image.sam import SpectralAngleMapper
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/image/test_ssim.py
+++ b/tests/unittests/image/test_ssim.py
@@ -23,8 +23,9 @@ from torch import Tensor
 
 from torchmetrics.functional import structural_similarity_index_measure
 from torchmetrics.image import StructuralSimilarityIndexMeasure
+from unittests import NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/image/test_uqi.py
+++ b/tests/unittests/image/test_uqi.py
@@ -20,8 +20,9 @@ from skimage.metrics import structural_similarity
 
 from torchmetrics.functional.image.uqi import universal_image_quality_index
 from torchmetrics.image.uqi import UniversalImageQualityIndex
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/nominal/test_cramers.py
+++ b/tests/unittests/nominal/test_cramers.py
@@ -23,7 +23,8 @@ from lightning_utilities.core.imports import compare_version
 
 from torchmetrics.functional.nominal.cramers import cramers_v, cramers_v_matrix
 from torchmetrics.nominal.cramers import CramersV
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests import BATCH_SIZE, NUM_BATCHES
+from unittests.helpers.testers import MetricTester
 
 Input = namedtuple("Input", ["preds", "target"])
 NUM_CLASSES = 4

--- a/tests/unittests/nominal/test_pearson.py
+++ b/tests/unittests/nominal/test_pearson.py
@@ -26,7 +26,8 @@ from torchmetrics.functional.nominal.pearson import (
     pearsons_contingency_coefficient_matrix,
 )
 from torchmetrics.nominal.pearson import PearsonsContingencyCoefficient
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests import BATCH_SIZE, NUM_BATCHES
+from unittests.helpers.testers import MetricTester
 
 Input = namedtuple("Input", ["preds", "target"])
 NUM_CLASSES = 4

--- a/tests/unittests/nominal/test_theils_u.py
+++ b/tests/unittests/nominal/test_theils_u.py
@@ -23,7 +23,8 @@ from lightning_utilities.core.imports import compare_version
 
 from torchmetrics.functional.nominal.theils_u import theils_u, theils_u_matrix
 from torchmetrics.nominal import TheilsU
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests import BATCH_SIZE, NUM_BATCHES
+from unittests.helpers.testers import MetricTester
 
 Input = namedtuple("Input", ["preds", "target"])
 NUM_CLASSES = 4

--- a/tests/unittests/nominal/test_tschuprows.py
+++ b/tests/unittests/nominal/test_tschuprows.py
@@ -23,7 +23,8 @@ from scipy.stats.contingency import association
 
 from torchmetrics.functional.nominal.tschuprows import tschuprows_t, tschuprows_t_matrix
 from torchmetrics.nominal.tschuprows import TschuprowsT
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests import BATCH_SIZE, NUM_BATCHES
+from unittests.helpers.testers import MetricTester
 
 Input = namedtuple("Input", ["preds", "target"])
 NUM_CLASSES = 4

--- a/tests/unittests/pairwise/test_pairwise_distance.py
+++ b/tests/unittests/pairwise/test_pairwise_distance.py
@@ -24,8 +24,9 @@ from torchmetrics.functional import (
     pairwise_linear_similarity,
     pairwise_manhattan_distance,
 )
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_concordance.py
+++ b/tests/unittests/regression/test_concordance.py
@@ -21,8 +21,9 @@ from scipy.stats import pearsonr
 
 from torchmetrics.functional.regression.concordance import concordance_corrcoef
 from torchmetrics.regression.concordance import ConcordanceCorrCoef
+from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_cosine_similarity.py
+++ b/tests/unittests/regression/test_cosine_similarity.py
@@ -21,8 +21,9 @@ from sklearn.metrics.pairwise import cosine_similarity as sk_cosine
 
 from torchmetrics.functional.regression.cosine_similarity import cosine_similarity
 from torchmetrics.regression.cosine_similarity import CosineSimilarity
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_explained_variance.py
+++ b/tests/unittests/regression/test_explained_variance.py
@@ -20,8 +20,9 @@ from sklearn.metrics import explained_variance_score
 
 from torchmetrics.functional import explained_variance
 from torchmetrics.regression import ExplainedVariance
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_kendall.py
+++ b/tests/unittests/regression/test_kendall.py
@@ -22,8 +22,9 @@ from scipy.stats import kendalltau
 
 from torchmetrics.functional.regression.kendall import kendall_rank_corrcoef
 from torchmetrics.regression.kendall import KendallRankCorrCoef
+from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 _SCIPY_GREATER_EQUAL_1_8 = compare_version("scipy", operator.ge, "1.8.0")
 

--- a/tests/unittests/regression/test_kl_divergence.py
+++ b/tests/unittests/regression/test_kl_divergence.py
@@ -23,8 +23,9 @@ from torch import Tensor
 
 from torchmetrics.functional.regression.kl_divergence import kl_divergence
 from torchmetrics.regression.kl_divergence import KLDivergence
+from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_log_cosh_error.py
+++ b/tests/unittests/regression/test_log_cosh_error.py
@@ -21,8 +21,9 @@ import torch
 
 from torchmetrics.functional.regression.log_cosh import log_cosh_error
 from torchmetrics.regression.log_cosh import LogCoshError
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_mean_error.py
+++ b/tests/unittests/regression/test_mean_error.py
@@ -42,8 +42,9 @@ from torchmetrics.regression import (
     WeightedMeanAbsolutePercentageError,
 )
 from torchmetrics.regression.symmetric_mape import SymmetricMeanAbsolutePercentageError
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_pearson.py
+++ b/tests/unittests/regression/test_pearson.py
@@ -20,8 +20,9 @@ from scipy.stats import pearsonr
 
 from torchmetrics.functional.regression.pearson import pearson_corrcoef
 from torchmetrics.regression.pearson import PearsonCorrCoef
+from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_r2.py
+++ b/tests/unittests/regression/test_r2.py
@@ -20,8 +20,9 @@ from sklearn.metrics import r2_score as sk_r2score
 
 from torchmetrics.functional import r2_score
 from torchmetrics.regression import R2Score
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_spearman.py
+++ b/tests/unittests/regression/test_spearman.py
@@ -20,8 +20,9 @@ from scipy.stats import rankdata, spearmanr
 
 from torchmetrics.functional.regression.spearman import _rank_data, spearman_corrcoef
 from torchmetrics.regression.spearman import SpearmanCorrCoef
+from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, NUM_CLASSES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/regression/test_tweedie_deviance.py
+++ b/tests/unittests/regression/test_tweedie_deviance.py
@@ -22,8 +22,9 @@ from torch import Tensor
 from torchmetrics.functional.regression.tweedie_deviance import tweedie_deviance_score
 from torchmetrics.regression.tweedie_deviance import TweedieDevianceScore
 from torchmetrics.utilities.imports import _TORCH_GREATER_EQUAL_1_9
+from unittests import BATCH_SIZE, NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/retrieval/inputs.py
+++ b/tests/unittests/retrieval/inputs.py
@@ -15,7 +15,7 @@ from collections import namedtuple
 
 import torch
 
-from unittests.helpers.testers import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES
+from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES
 
 Input = namedtuple("InputMultiple", ["indexes", "preds", "target"])
 

--- a/tests/unittests/retrieval/test_fallout.py
+++ b/tests/unittests/retrieval/test_fallout.py
@@ -56,7 +56,7 @@ class TestFallOut(RetrievalMetricTester):
     @pytest.mark.parametrize("ddp", [True, False])
     @pytest.mark.parametrize("empty_target_action", ["skip", "neg", "pos"])
     @pytest.mark.parametrize("ignore_index", [None, 1])  # avoid setting 0, otherwise test with all 0 targets will fail
-    @pytest.mark.parametrize("k", [None, 1, 4, 10])
+    @pytest.mark.parametrize("k", [None, 1, 10])
     @pytest.mark.parametrize(**_default_metric_class_input_arguments)
     def test_class_metric(
         self,

--- a/tests/unittests/text/helpers.py
+++ b/tests/unittests/text/helpers.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import contextlib
 import pickle
 import sys
 from functools import partial, wraps
@@ -23,11 +22,8 @@ from torch import Tensor
 from torch.multiprocessing import set_start_method
 
 from torchmetrics import Metric
+from unittests import NUM_PROCESSES
 from unittests.helpers.testers import MetricTester, _assert_allclose, _assert_requires_grad, _assert_tensor
-
-with contextlib.suppress(RuntimeError):
-    set_start_method("spawn")
-
 
 TEXT_METRIC_INPUT = Union[Sequence[str], Sequence[Sequence[str]], Sequence[Sequence[Sequence[str]]]]
 NUM_BATCHES = 2
@@ -315,7 +311,7 @@ class TextTester(MetricTester):
             if sys.platform == "win32":
                 pytest.skip("DDP not supported on windows")
 
-            self.pool.starmap(
+            pytest.pool.starmap(
                 partial(
                     _class_test,
                     preds=preds,
@@ -332,7 +328,7 @@ class TextTester(MetricTester):
                     key=key,
                     **kwargs_update,
                 ),
-                [(rank, self.pool_size) for rank in range(self.pool_size)],
+                [(rank, NUM_PROCESSES) for rank in range(NUM_PROCESSES)],
             )
         else:
             device = "cuda" if (torch.cuda.is_available() and torch.cuda.device_count() > 0) else "cpu"

--- a/tests/unittests/text/inputs.py
+++ b/tests/unittests/text/inputs.py
@@ -15,8 +15,8 @@ from collections import namedtuple
 
 import torch
 
+from unittests import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, NUM_CLASSES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, EXTRA_DIM, NUM_BATCHES, NUM_CLASSES
 
 seed_all(1)
 

--- a/tests/unittests/utilities/test_auc.py
+++ b/tests/unittests/utilities/test_auc.py
@@ -20,8 +20,9 @@ from sklearn.metrics import auc as _sk_auc
 from torch import tensor
 
 from torchmetrics.utilities.compute import auc
+from unittests import NUM_BATCHES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import NUM_BATCHES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/wrappers/test_minmax.py
+++ b/tests/unittests/wrappers/test_minmax.py
@@ -8,8 +8,9 @@ from torch import Tensor
 from torchmetrics import MeanSquaredError
 from torchmetrics.classification import BinaryAccuracy, BinaryConfusionMatrix, MulticlassAccuracy
 from torchmetrics.wrappers import MinMaxMetric
+from unittests import BATCH_SIZE, NUM_BATCHES, NUM_CLASSES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, NUM_CLASSES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 

--- a/tests/unittests/wrappers/test_multioutput.py
+++ b/tests/unittests/wrappers/test_multioutput.py
@@ -11,8 +11,9 @@ from torchmetrics import Metric
 from torchmetrics.classification import ConfusionMatrix, MulticlassAccuracy
 from torchmetrics.regression import R2Score
 from torchmetrics.wrappers.multioutput import MultioutputWrapper
+from unittests import BATCH_SIZE, NUM_BATCHES, NUM_CLASSES
 from unittests.helpers import seed_all
-from unittests.helpers.testers import BATCH_SIZE, NUM_BATCHES, NUM_CLASSES, MetricTester
+from unittests.helpers.testers import MetricTester
 
 seed_all(42)
 


### PR DESCRIPTION
## What does this PR do?

Improve CI testing time by starting a single pool of workers for running tests in ddp, instead of doing this per test class.
Starting a new pool of workers takes around 5 sec and with this currently being done around 100 times throughout testing, that means we should save ~500 sec with this change.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
