### PR TITLE
ci/azure: try to use local tmp as cache

### DIFF
--- a/.azure/gpu-pipeline.yml
+++ b/.azure/gpu-pipeline.yml
@@ -37,7 +37,10 @@ jobs:
 
     variables:
       DEVICES: $( python -c 'name = "$(Agent.Name)" ; gpus = name.split("_")[-1] if "_" in name else "0,1"; print(gpus)' )
-      TRANSFORMERS_CACHE: "$(Pipeline.Workspace)/ci-cache_huggingface"
+      # these two caches assume to run repetitively on the same set of machines
+      #  see: https://github.com/microsoft/azure-pipelines-agent/issues/4113#issuecomment-1439241481
+      TORCH_HOME: "/var/tmp/torch"
+      TRANSFORMERS_CACHE: "/var/tmp/huggingface"
       FREEZE_REQUIREMENTS: 1
 
     container:
@@ -97,11 +100,6 @@ jobs:
         python -c "import torch ; mgpu = torch.cuda.device_count() ; assert mgpu >= 2, f'GPU: {mgpu}'"
       displayName: 'Sanity check'
 
-    #- task: Cache@2
-    #  inputs:
-    #    key: transformers
-    #    path: $(TRANSFORMERS_CACHE)
-    #    cacheHitVar: HF_CACHE_RESTORED
     - bash: |
         printf "cache location: $(TRANSFORMERS_CACHE)\n"
         # printf "hit the HF cache: $(variables.HF_CACHE_RESTORED)\n"


### PR DESCRIPTION
## What does this PR do?

These two caches assume to run repetitively on the same set of machines, see: https://github.com/microsoft/azure-pipelines-agent/issues/4113#issuecomment-1439241481
Recently LPIPS tests are failing on too long download...
```
=========================== short test summary info ============================
FAILED unittests/image/test_lpips.py::TestLPIPS::test_lpips[True-alex] - Failed: Timeout >180.0s
= 1 failed, 14609 passed, 2594 skipped, 233 xfailed, 82920 warnings in 1726.62s (0:28:46) 
```
from: https://dev.azure.com/Lightning-AI/Metrics/_build/results?buildId=139520&view=logs&jobId=5ea502cf-d418-510c-3b5f-c4ba606ae534&j=5ea502cf-d418-510c-3b5f-c4ba606ae534&t=57b60c4d-cdd2-5de4-7280-053079a62e84

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [x] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
