### PR TITLE
Prevent metric state dtype conversion when metric is part of LightningModule

### DIFF
--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -697,9 +697,14 @@ class Metric(Module, ABC):
     def _apply(self, fn: Callable) -> Module:
         """Overwrite _apply function such that we can also move metric states to the correct device.
 
-        This method is called by the base ``nn.Module`` class whenever `.to`, `.cuda`, etc. methods are called.
+        This method is called by the base ``nn.Module`` class whenever `.to`, `.cuda`, etc. methods are called,
+        however .half() and .float() calls are not applied on metric states and defaults.
         """
         this = super()._apply(fn)
+
+        if "Module.half" in str(fn) or "Module.float" in str(fn):
+            return this
+
         # Also apply fn to metric states and defaults
         for key, value in this._defaults.items():
             if isinstance(value, Tensor):

--- a/tests/unittests/bases/test_metric.py
+++ b/tests/unittests/bases/test_metric.py
@@ -21,9 +21,9 @@ import numpy as np
 import psutil
 import pytest
 import torch
-from torch import Tensor, tensor
-from torch.nn import Module, Linear
 from pytorch_lightning import LightningModule
+from torch import Tensor, tensor
+from torch.nn import Linear, Module
 
 from torchmetrics import PearsonCorrCoef
 from torchmetrics.classification import BinaryAccuracy
@@ -299,6 +299,7 @@ def test_device_and_dtype_transfer(tmpdir):
 
 def test_dtype_in_pl_module_transfer(tmpdir):
     """Test that metric states don't change dtype when .half() or .float() is called on the LightningModule."""
+
     class BoringModel(LightningModule):
         def __init__(self, metric_dtype=torch.float32):
             super().__init__()
@@ -318,7 +319,7 @@ def test_dtype_in_pl_module_transfer(tmpdir):
 
         def configure_optimizers(self):
             return torch.optim.SGD(self.layer.parameters(), lr=0.1)
-    
+
     model = BoringModel()
     assert model.metric.x.dtype == torch.float32
     model = model.half()


### PR DESCRIPTION
## What does this PR do?

Fixes #1561 

Added a simple check to prevent applying `.half()` and `.float()` calls that are passed on the LightningModule to metric states and defaults. Instead, users will have to use `set_dtype()`, as proposed in #493. 

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [X] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [X] Did you make sure to **update the docs**?
- [X] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
