### PR TITLE
Enchance use of `data_range` in image metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for plotting of aggregation metrics through `.plot()` method ([#1485](https://github.com/Lightning-AI/metrics/pull/1485))
 
+
+- Added support for auto clamping of input for metrics that uses the `data_range` ([#1606](argument https://github.com/Lightning-AI/metrics/pull/1606))
+
 ### Changed
 
 - Changed `update_count` and `update_called` from private to public methods ([#1370](https://github.com/Lightning-AI/metrics/pull/1370))

--- a/src/torchmetrics/functional/image/psnr.py
+++ b/src/torchmetrics/functional/image/psnr.py
@@ -88,7 +88,7 @@ def _psnr_update(
 def peak_signal_noise_ratio(
     preds: Tensor,
     target: Tensor,
-    data_range: Optional[float] = None,
+    data_range: Optional[Union[float, Tuple[float, float]]] = None,
     base: float = 10.0,
     reduction: Literal["elementwise_mean", "sum", "none", None] = "elementwise_mean",
     dim: Optional[Union[int, Tuple[int, ...]]] = None,
@@ -98,8 +98,10 @@ def peak_signal_noise_ratio(
     Args:
         preds: estimated signal
         target: groun truth signal
-        data_range: the range of the data. If None, it is determined from the data (max - min).
-            ``data_range`` must be given when ``dim`` is not None.
+        data_range:
+            the range of the data. If None, it is determined from the data (max - min). If a tuple is provided then
+            the range is calculated as the difference and input is clamped between the values.
+            The ``data_range`` must be given when ``dim`` is not None.
         base: a base of a logarithm to use
         reduction: a method to reduce metric score over labels.
 
@@ -138,7 +140,12 @@ def peak_signal_noise_ratio(
             raise ValueError("The `data_range` must be given when `dim` is not None.")
 
         data_range = target.max() - target.min()
+    elif isinstance(data_range, tuple):
+        preds = torch.clamp(preds, min=data_range[0], max=data_range[1])
+        target = torch.clamp(target, min=data_range[0], max=data_range[1])
+        data_range = tensor(data_range[1] - data_range[0])
     else:
         data_range = tensor(float(data_range))
+
     sum_squared_error, n_obs = _psnr_update(preds, target, dim=dim)
     return _psnr_compute(sum_squared_error, n_obs, data_range, base=base, reduction=reduction)

--- a/src/torchmetrics/functional/image/ssim.py
+++ b/src/torchmetrics/functional/image/ssim.py
@@ -47,7 +47,7 @@ def _ssim_update(
     gaussian_kernel: bool = True,
     sigma: Union[float, Sequence[float]] = 1.5,
     kernel_size: Union[int, Sequence[int]] = 11,
-    data_range: Optional[float] = None,
+    data_range: Optional[Union[float, Tuple[float, float]]] = None,
     k1: float = 0.01,
     k2: float = 0.03,
     return_full_image: bool = False,
@@ -109,6 +109,10 @@ def _ssim_update(
 
     if data_range is None:
         data_range = max(preds.max() - preds.min(), target.max() - target.min())
+    elif isinstance(data_range, tuple):
+        preds = torch.clamp(preds, min=data_range[0], max=data_range[1])
+        target = torch.clamp(target, min=data_range[0], max=data_range[1])
+        data_range = data_range[1] - data_range[0]
 
     c1 = pow(k1 * data_range, 2)
     c2 = pow(k2 * data_range, 2)
@@ -202,7 +206,7 @@ def structural_similarity_index_measure(
     sigma: Union[float, Sequence[float]] = 1.5,
     kernel_size: Union[int, Sequence[int]] = 11,
     reduction: Literal["elementwise_mean", "sum", "none", None] = "elementwise_mean",
-    data_range: Optional[float] = None,
+    data_range: Optional[Union[float, Tuple[float, float]]] = None,
     k1: float = 0.01,
     k2: float = 0.03,
     return_full_image: bool = False,
@@ -224,7 +228,9 @@ def structural_similarity_index_measure(
             - ``'sum'``: takes the sum
             - ``'none'`` or ``None``: no reduction will be applied
 
-        data_range: Range of the image. If ``None``, it is determined from the image (max - min)
+        data_range:
+            the range of the data. If None, it is determined from the data (max - min). If a tuple is provided then
+            the range is calculated as the difference and input is clamped between the values.
         k1: Parameter of SSIM.
         k2: Parameter of SSIM.
         return_full_image: If true, the full ``ssim`` image is returned as a second argument.
@@ -283,7 +289,7 @@ def _get_normalized_sim_and_cs(
     gaussian_kernel: bool = True,
     sigma: Union[float, Sequence[float]] = 1.5,
     kernel_size: Union[int, Sequence[int]] = 11,
-    data_range: Optional[float] = None,
+    data_range: Optional[Union[float, Tuple[float, float]]] = None,
     k1: float = 0.01,
     k2: float = 0.03,
     normalize: Optional[Literal["relu", "simple"]] = None,
@@ -311,7 +317,7 @@ def _multiscale_ssim_update(
     gaussian_kernel: bool = True,
     sigma: Union[float, Sequence[float]] = 1.5,
     kernel_size: Union[int, Sequence[int]] = 11,
-    data_range: Optional[float] = None,
+    data_range: Optional[Union[float, Tuple[float, float]]] = None,
     k1: float = 0.01,
     k2: float = 0.03,
     betas: Union[Tuple[float, float, float, float, float], Tuple[float, ...]] = (
@@ -436,7 +442,7 @@ def multiscale_structural_similarity_index_measure(
     sigma: Union[float, Sequence[float]] = 1.5,
     kernel_size: Union[int, Sequence[int]] = 11,
     reduction: Literal["elementwise_mean", "sum", "none", None] = "elementwise_mean",
-    data_range: Optional[float] = None,
+    data_range: Optional[Union[float, Tuple[float, float]]] = None,
     k1: float = 0.01,
     k2: float = 0.03,
     betas: Tuple[float, ...] = (0.0448, 0.2856, 0.3001, 0.2363, 0.1333),
@@ -459,7 +465,9 @@ def multiscale_structural_similarity_index_measure(
             - ``'sum'``: takes the sum
             - ``'none'`` or ``None``: no reduction will be applied
 
-        data_range: Range of the image. If ``None``, it is determined from the image (max - min)
+        data_range:
+            the range of the data. If None, it is determined from the data (max - min). If a tuple is provided then
+            the range is calculated as the difference and input is clamped between the values.
         k1: Parameter of structural similarity index measure.
         k2: Parameter of structural similarity index measure.
         betas: Exponent parameters for individual similarities and contrastive sensitivies returned by different image

--- a/src/torchmetrics/image/psnr.py
+++ b/src/torchmetrics/image/psnr.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from functools import partial
 from typing import Any, Optional, Sequence, Tuple, Union
 
 import torch
@@ -46,7 +47,8 @@ class PeakSignalNoiseRatio(Metric):
 
     Args:
         data_range:
-            the range of the data. If None, it is determined from the data (max - min).
+            the range of the data. If None, it is determined from the data (max - min). If a tuple is provided then
+            the range is calculated as the difference and input is clamped between the values.
             The ``data_range`` must be given when ``dim`` is not None.
         base: a base of a logarithm to use.
         reduction: a method to reduce metric score over labels.
@@ -83,7 +85,7 @@ class PeakSignalNoiseRatio(Metric):
 
     def __init__(
         self,
-        data_range: Optional[float] = None,
+        data_range: Optional[Union[float, Tuple[float, float]]] = None,
         base: float = 10.0,
         reduction: Literal["elementwise_mean", "sum", "none", None] = "elementwise_mean",
         dim: Optional[Union[int, Tuple[int, ...]]] = None,
@@ -101,6 +103,7 @@ class PeakSignalNoiseRatio(Metric):
             self.add_state("sum_squared_error", default=[], dist_reduce_fx="cat")
             self.add_state("total", default=[], dist_reduce_fx="cat")
 
+        self.clamping_fn = None
         if data_range is None:
             if dim is not None:
                 # Maybe we could use `torch.amax(target, dim=dim) - torch.amin(target, dim=dim)` in PyTorch 1.7 to
@@ -110,6 +113,9 @@ class PeakSignalNoiseRatio(Metric):
             self.data_range = None
             self.add_state("min_target", default=tensor(0.0), dist_reduce_fx=torch.min)
             self.add_state("max_target", default=tensor(0.0), dist_reduce_fx=torch.max)
+        elif isinstance(data_range, tuple):
+            self.add_state("data_range", default=tensor(data_range[1] - data_range[0]), dist_reduce_fx="mean")
+            self.clamping_fn = partial(torch.clamp, min=data_range[0], max=data_range[1])
         else:
             self.add_state("data_range", default=tensor(float(data_range)), dist_reduce_fx="mean")
         self.base = base
@@ -118,6 +124,10 @@ class PeakSignalNoiseRatio(Metric):
 
     def update(self, preds: Tensor, target: Tensor) -> None:
         """Update state with predictions and targets."""
+        if self.clamping_fn is not None:
+            preds = self.clamping_fn(preds)
+            target = self.clamping_fn(target)
+
         sum_squared_error, n_obs = _psnr_update(preds, target, dim=self.dim)
         if self.dim is None:
             if self.data_range is None:

--- a/src/torchmetrics/image/ssim.py
+++ b/src/torchmetrics/image/ssim.py
@@ -54,7 +54,9 @@ class StructuralSimilarityIndexMeasure(Metric):
             - ``'sum'``: takes the sum
             - ``'none'`` or ``None``: no reduction will be applied
 
-        data_range: Range of the image. If ``None``, it is determined from the image (max - min)
+        data_range:
+            the range of the data. If None, it is determined from the data (max - min). If a tuple is provided then
+            the range is calculated as the difference and input is clamped between the values.
         k1: Parameter of SSIM.
         k2: Parameter of SSIM.
         return_full_image: If true, the full ``ssim`` image is returned as a second argument.
@@ -89,7 +91,7 @@ class StructuralSimilarityIndexMeasure(Metric):
         sigma: Union[float, Sequence[float]] = 1.5,
         kernel_size: Union[int, Sequence[int]] = 11,
         reduction: Literal["elementwise_mean", "sum", "none", None] = "elementwise_mean",
-        data_range: Optional[float] = None,
+        data_range: Optional[Union[float, Tuple[float, float]]] = None,
         k1: float = 0.01,
         k2: float = 0.03,
         return_full_image: bool = False,
@@ -239,7 +241,10 @@ class MultiScaleStructuralSimilarityIndexMeasure(Metric):
             - ``'sum'``: takes the sum
             - ``'none'`` or ``None``: no reduction will be applied
 
-        data_range: Range of the image. If ``None``, it is determined from the image (max - min)
+        data_range:
+            the range of the data. If None, it is determined from the data (max - min). If a tuple is provided then
+            the range is calculated as the difference and input is clamped between the values.
+            The ``data_range`` must be given when ``dim`` is not None.
         k1: Parameter of structural similarity index measure.
         k2: Parameter of structural similarity index measure.
         betas: Exponent parameters for individual similarities and contrastive sensitivies returned by different image
@@ -285,7 +290,7 @@ class MultiScaleStructuralSimilarityIndexMeasure(Metric):
         kernel_size: Union[int, Sequence[int]] = 11,
         sigma: Union[float, Sequence[float]] = 1.5,
         reduction: Literal["elementwise_mean", "sum", "none", None] = "elementwise_mean",
-        data_range: Optional[float] = None,
+        data_range: Optional[Union[float, Tuple[float, float]]] = None,
         k1: float = 0.01,
         k2: float = 0.03,
         betas: Tuple[float, ...] = (0.0448, 0.2856, 0.3001, 0.2363, 0.1333),

--- a/tests/unittests/image/test_psnr.py
+++ b/tests/unittests/image/test_psnr.py
@@ -60,6 +60,10 @@ def _to_sk_peak_signal_noise_ratio_inputs(value, dim):
 
 
 def _skimage_psnr(preds, target, data_range, reduction, dim):
+    if isinstance(data_range, tuple):
+        preds = preds.clamp(min=data_range[0], max=data_range[1])
+        target = target.clamp(min=data_range[0], max=data_range[1])
+        data_range = data_range[1] - data_range[0]
     sk_preds_lists = _to_sk_peak_signal_noise_ratio_inputs(preds, dim=dim)
     sk_target_lists = _to_sk_peak_signal_noise_ratio_inputs(target, dim=dim)
     np_reduce_map = {"elementwise_mean": np.mean, "none": np.array, "sum": np.sum}
@@ -84,6 +88,7 @@ def _base_e_sk_psnr(preds, target, data_range, reduction, dim):
         (_inputs[2].preds, _inputs[2].target, 5, "elementwise_mean", 1),
         (_inputs[2].preds, _inputs[2].target, 5, "elementwise_mean", (1, 2)),
         (_inputs[2].preds, _inputs[2].target, 5, "sum", (1, 2)),
+        (_inputs[0].preds, _inputs[0].target, (0.0, 1.0), "elementwise_mean", None),
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/unittests/image/test_ssim.py
+++ b/tests/unittests/image/test_ssim.py
@@ -65,6 +65,10 @@ def _skimage_ssim(
     gaussian_weights=True,
     reduction_arg="elementwise_mean",
 ):
+    if isinstance(data_range, tuple):
+        preds = preds.clamp(min=data_range[0], max=data_range[1])
+        target = target.clamp(min=data_range[0], max=data_range[1])
+        data_range = data_range[1] - data_range[0]
     if len(preds.shape) == 4:
         c, h, w = preds.shape[-3:]
         sk_preds = preds.view(-1, c, h, w).permute(0, 2, 3, 1).numpy()
@@ -136,17 +140,18 @@ class TestSSIM(MetricTester):
 
     atol = 6e-3
 
+    @pytest.mark.parametrize("data_range", [1.0, (0.1, 1.0)])
     @pytest.mark.parametrize("ddp", [True, False])
-    def test_ssim_sk(self, preds, target, sigma, ddp):
+    def test_ssim_sk(self, preds, target, sigma, data_range, ddp):
         """Test class implementation of metricvs skimage."""
         self.run_class_metric_test(
             ddp,
             preds,
             target,
             StructuralSimilarityIndexMeasure,
-            partial(_skimage_ssim, data_range=1.0, sigma=sigma, kernel_size=None),
+            partial(_skimage_ssim, data_range=data_range, sigma=sigma, kernel_size=None),
             metric_args={
-                "data_range": 1.0,
+                "data_range": data_range,
                 "sigma": sigma,
             },
         )


### PR DESCRIPTION
## What does this PR do?

Fixes #1592
Add additional option for the `data_range` to be used as an tuple that auto clamps input.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
