### PR TITLE
Fix restrictive input in pearson corr coef

### DIFF
--- a/src/torchmetrics/functional/regression/utils.py
+++ b/src/torchmetrics/functional/regression/utils.py
@@ -21,7 +21,9 @@ def _check_data_shape_to_num_outputs(preds: Tensor, target: Tensor, num_outputs:
             f"Expected both predictions and target to be either 1- or 2-dimensional tensors,"
             f" but got {target.ndim} and {preds.ndim}."
         )
-    if (num_outputs == 1 and preds.ndim != 1) or (num_outputs > 1 and num_outputs != preds.shape[1]):
+    cond1 = num_outputs == 1 and not (preds.ndim == 1 or preds.shape[1] == 1)
+    cond2 = num_outputs > 1 and num_outputs != preds.shape[1]
+    if cond1 or cond2:
         raise ValueError(
             f"Expected argument `num_outputs` to match the second dimension of input, but got {num_outputs}"
             f" and {preds.shape[1]}."

--- a/tests/unittests/regression/test_pearson.py
+++ b/tests/unittests/regression/test_pearson.py
@@ -129,6 +129,12 @@ def test_error_on_different_shape():
         metric(torch.randn(100, 5), torch.randn(100, 5))
 
 
+def test_1d_input_allowed():
+    """Check that both input of the form [N,] and [N,1] is allowed with default num_outputs argument."""
+    assert isinstance(pearson_corrcoef(torch.randn(10, 1), torch.randn(10, 1)), torch.Tensor)
+    assert isinstance(pearson_corrcoef(torch.randn(10), torch.randn(10)), torch.Tensor)
+
+
 @pytest.mark.parametrize("shapes", [(5,), (1, 5), (2, 5)])
 def test_final_aggregation_function(shapes):
     """Test that final aggregation function can take various shapes of input."""


### PR DESCRIPTION
## What does this PR do?

Fixes #1647
One of the check of the input is a bit too restrictive, such that only input of the form `[N,1]` is allowed but not `[N,]`. Changes the check to allow both.

<details>
  <summary>Before submitting</summary>

- [ ] Was this **discussed/agreed** via a Github issue? (no need for typos and docs improvements)
- [ ] Did you read the [contributor guideline](https://github.com/Lightning-AI/metrics/blob/master/.github/CONTRIBUTING.md), Pull Request section?
- [ ] Did you make sure to **update the docs**?
- [ ] Did you write any new **necessary tests**?

</details>

<details>
  <summary>PR review</summary>

Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

</details>

## Did you have fun?

Make sure you had fun coding 🙃
