### PR TITLE
Silently failing DDP syncing when initializing Metric with jsonargparse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed support in `MetricTracker` for `MultioutputWrapper` and nested structures ([#1608](https://github.com/Lightning-AI/metrics/pull/1608))
 
 
+- Fixed integration with `jsonargparse` and `LightningCLI` ([#1651](https://github.com/Lightning-AI/metrics/pull/1651))
+
+
 ## [0.11.4] - 2023-03-10
 
 ### Fixed

--- a/src/torchmetrics/metric.py
+++ b/src/torchmetrics/metric.py
@@ -124,7 +124,7 @@ class Metric(Module, ABC):
                 f"Expected keyword argument `dist_sync_fn` to be an callable function but got {self.dist_sync_fn}"
             )
 
-        self.distributed_available_fn = kwargs.pop("distributed_available_fn", jit_distributed_available)
+        self.distributed_available_fn = kwargs.pop("distributed_available_fn", None) or jit_distributed_available
 
         self.sync_on_compute = kwargs.pop("sync_on_compute", True)
         if not isinstance(self.sync_on_compute, bool):


### PR DESCRIPTION
`Metric`s silently fail to sync across gpus when initialized with jsonargparse (as used in the LightningCLI)

This PR fixes this issue.

This happens due the following combination of factors.
- jsonargparse has a docstring parsing function enabled when installed with `pip install jsonargparse[signatures]`
- `torchmetrics.Metric` has a docstring that mentions an optional` distributed_available_fn`
- If `distributed_available_fn` is not set in `**kwargs`, `Metric.__init__` sets a default pytorch function which enables ddp syncing of metrics
- When a metric is initialized in a yaml config, jsonargparse recognizes the `distributed_available_fn` field in the docstring of `Metric.__init__` and passes a default value of `distributed_available_fn=None` when initializing the metric object.
- Hence, any subclass of `Metric` initialized by jsonargparse has `distributed_available_fn = None`. These metrics silently fail to sync across gpus.

## What does this PR do?

Fix broken ddp syncing of metrics.

## Did you have fun?

I had a fun two days debugging this issue :-).
